### PR TITLE
TC_00.002-02 | New Item > Create Pipeline Project | Pipeline item type is highlighted when selected

### DIFF
--- a/cypress/e2e/newItemCreatePipelineProject.cy.js
+++ b/cypress/e2e/newItemCreatePipelineProject.cy.js
@@ -1,0 +1,11 @@
+/// <reference types="cypress" />
+describe('New Item > Create Pipeline Project', () => {
+    const newItemName = 'New Item Name';
+    it('Pipeline item type is highlighted when selected', () => {
+        cy.get('span').contains('New Item').click()
+        cy.get('input#name').type(newItemName)
+        cy.get('span.label').contains('Pipeline').click();
+        cy.get('.org_jenkinsci_plugins_workflow_job_WorkflowJob')
+            .should('have.attr', 'aria-checked', 'true');
+    })
+})


### PR DESCRIPTION
**Changes**

1. added new spec file: newItemCreatePipelineProject.cy.js
2. added test: Pipeline item type is highlighted when selected

**Test Case**
- https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/108

**Test**
- tested locally and new test is passing

<img width="996" alt="Screenshot 2024-11-18 at 23 00 26" src="https://github.com/user-attachments/assets/3b6fd523-56c9-4637-af7e-23cc796d89b9">


