### PR TITLE
TC_14.002.10 | Verify that the warning message is displayed when no matches are found

### DIFF
--- a/cypress/e2e/headerSearchBox.cy.js
+++ b/cypress/e2e/headerSearchBox.cy.js
@@ -60,4 +60,12 @@ describe('US_14.002 | Header > Search Box', () => {
 
   });
 
+  it('TC_14.002.10 | Verify that the warning message is displayed when no matches are found', () => {
+    
+    cy.get('input#search-box').type('no matches{Enter}');
+
+    cy.get('.error').should('have.text', 'Nothing seems to match.');
+    
+  });
+
 });


### PR DESCRIPTION
[TC_14.002.10](https://github.com/orgs/RedRoverSchool/projects/4/views/1?filterQuery=14.002+&pane=issue&itemId=87890218&issue=RedRoverSchool%7CJenkinsQA_JS_2024_fall%7C186)