### PR TITLE
TC_00.000.10-A | New Item > Create New item | Verify that to create a new item, user should choose 'an item type' first

### DIFF
--- a/cypress/e2e/newItemCreateNewItem.cy.js
+++ b/cypress/e2e/newItemCreateNewItem.cy.js
@@ -150,4 +150,17 @@ describe("US_00.000 | New Item > Create New item", () => {
 
         cy.get('table.jenkins-table.sortable').contains(jobName).should("exist");
     })
+
+    it('TC_00.000.10 | Verify that to create a new item, user should choose "an item type" first', () => {
+
+        cy.get('span').contains('New Item').click()
+        cy.get('input#name.jenkins-input').type(jobName)
+        cy.get('#ok-button').contains('OK').should('be.disabled')
+        cy.get('span').contains('Freestyle project').click()
+        cy.get('#ok-button').contains('OK').should('be.enabled')
+        cy.get('#ok-button').click()
+        cy.get('a#jenkins-home-link').click()
+
+        cy.get('table.jenkins-table.sortable').contains(jobName).should('exist')
+    })
 })


### PR DESCRIPTION
Added test case 'Verify that to create a new item, user should choose 'an item type' first'. The test passed all checks locally.

![TC_00 000 10  Verify that to create a new item, user should choose an item type first](https://github.com/user-attachments/assets/54106fec-2007-4183-b44d-236fa5e79bd8)

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/220
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/15