### PR TITLE
TC_00.000.13-A | New Item > Create New item | Verify that after saving, new item is present on dashboard

### DIFF
--- a/cypress/e2e/newItemCreateNewItem.cy.js
+++ b/cypress/e2e/newItemCreateNewItem.cy.js
@@ -182,4 +182,16 @@ describe("US_00.000 | New Item > Create New item", () => {
         cy.get('button[data-section-id="pipeline"]').contains('Pipeline')
         cy.get('button[data-section-id="pipeline"]').should('be.visible')
     })
+
+    it('TC_00.000.13 | Verify that after saving, new item is present on dashboard', () => {
+
+        cy.get('span').contains('New Item').click()
+        cy.get('input#name.jenkins-input').type(jobName)
+        cy.get('span.label').contains('Freestyle project').click()
+        cy.get('#ok-button').click()
+        cy.get('button[name="Submit"]').contains('Save').click()
+        cy.get('a#jenkins-home-link').click()
+        
+        cy.get('table.jenkins-table.sortable').contains(jobName).should('be.visible')
+    })
 })


### PR DESCRIPTION
Added test case 'Verify that after saving, new item is present on dashboard'. The test passed all checks locally.

![TC_00 000 13  Verify that after saving, new item is present on dashboard](https://github.com/user-attachments/assets/6c20d8e3-7919-49cf-8e71-92a6c681e343)

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/248
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/15