### PR TITLE
TC_00.000.14-A | New Item > Create New item | Verify the display of validation message if no item name is entered

### DIFF
--- a/cypress/e2e/newItemCreateNewItem.cy.js
+++ b/cypress/e2e/newItemCreateNewItem.cy.js
@@ -194,4 +194,14 @@ describe("US_00.000 | New Item > Create New item", () => {
         
         cy.get('table.jenkins-table.sortable').contains(jobName).should('be.visible')
     })
+
+    it('TC_00.000.14 | Verify the display of validation message if no item name is entered', () => {
+
+        cy.get('span').contains('New Item').click()
+        cy.get('input#name.jenkins-input').type(jobName)
+        cy.get('input#name.jenkins-input').clear()
+
+        cy.get('#itemname-required.input-validation-message').should('have.text', '» This field cannot be empty, please enter a valid name')
+        cy.get('#ok-button').contains('OK').should('be.disabled')
+    })
 })


### PR DESCRIPTION
Added test case 'Verify the display of validation message if no item name is entered'. The test passed locally.

![TC_00 000 14 Verify the display of validation message if no item name is entered](https://github.com/user-attachments/assets/ca475598-2221-4423-8b04-b0d1570b0acc)

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/263
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/15