### PR TITLE
RF_01.001.08 | FreestyleProject > Add description | Verify the description is added when creating the project

### DIFF
--- a/cypress/e2e/freestyleProjectAddDescriptionPOM.cy.js
+++ b/cypress/e2e/freestyleProjectAddDescriptionPOM.cy.js
@@ -94,13 +94,15 @@ describe("US_01.001 | FreestyleProject > Add description", () => {
   
   it('TC_01.001.08-A | Verify the description is added when creating the project', () => {
 
-    cy.log('Adding description and saving the project')
-    cy.get(descriptionField)
-      .type(projectDescription)
-    cy.get(submitBtn).click()
+    cy.log('Adding description and saving the project');
+    projectConfigure
+        .addNewProjDescription(projectDescription)
+        .clickSaveBtn();
 
-    cy.log('Verifying the Freestyle Project was saved together with its description')
-    cy.get(projectNameHeadline).should('be.visible').and('exist')
-    cy.get(description).should('be.visible').and('contain.text', projectDescription)
+    cy.log('Verifying the Freestyle Project was saved together with its description');
+    jobPage
+        .getHeadlineIndex().should('be.visible').and('exist');
+    jobPage
+        .getProjectDescription().should('be.visible').and('contain.text', projectDescription);
   })
 });


### PR DESCRIPTION
Converted TC_01.001.08 'Verify the description is added when creating the project' to POM format. The test passed.

![TC_01 001 08-A  Verify the description is added when creating the project](https://github.com/user-attachments/assets/92740a77-f6cf-405f-97b9-36b7581a533b)

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/397
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/12