### PR TITLE
RF_01.001.09 | FreestyleProject > Add description | Description is shown on project page

### DIFF
--- a/cypress/e2e/freestyleProjectAddDescriptionPOM.cy.js
+++ b/cypress/e2e/freestyleProjectAddDescriptionPOM.cy.js
@@ -57,4 +57,12 @@ describe("US_01.001 | FreestyleProject > Add description", () => {
       .getJobDescription().should('be.visible').and('contain.text', jobDescription);
   });
 
+  it('TC_01.001.09 | Description is shown on project page', () => {
+
+    freestyleProjectPage
+        .typeJobDescription(jobDescription)
+        .clickSaveButton();
+
+    freestyleProjectPage.getJobDescription().should('contain.text', jobDescription)
+  });
 });

--- a/cypress/e2e/oldTests/freestyleProjectAddDescription.cy.js
+++ b/cypress/e2e/oldTests/freestyleProjectAddDescription.cy.js
@@ -107,7 +107,7 @@ describe.skip("US_01.001 | FreestyleProject > Add description", () => {
     cy.get(description).should('be.visible').and('contain.text', projectDescription)
   })
 
-  it('TC_01.001.09 | Description is shown on project page', () => {
+  it.skip('TC_01.001.09 | Description is shown on project page', () => {
 
     cy.get(descriptionTextAreaField).type(projectDescription)
     cy.get(submitBtn).click()


### PR DESCRIPTION
[RF_01.001.09 | FreestyleProject > Add description | Description is shown on project page](https://github.com/orgs/RedRoverSchool/projects/4/views/1?pane=issue&itemId=88907400)


In the test file:

1. **freestyleProjectAddDescriptionPOM.cy.js** :  added TC_01.001.09-A | Description is shown on project page test case using POM


2. **freestyleProjectAddDescription.cy.js** added `.skip` to my test


Tests passed locally:
<img width="1230" alt="Screenshot 2024-11-27 at 19 35 00" src="https://github.com/user-attachments/assets/027389e6-6709-4b01-910c-7309b290b8ec">




___

**Description:**
As a registered user,
I want to be able to add a description to my project,
so that I can share project information, team instructions, etc, with my team

**Steps:**

1. From Dashboard select New Item
2. Provide Item Name and select Freestyle Project
3. Click OK
4. Describe your project
5. Save the project

**Expected**
The provided description is shown on the project page.