### PR TITLE
RF_01.004.10 | FreestyleProject > Delete Project | Verify Freestyle Project is deleted from Dashboard page

### DIFF
--- a/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress"/>
 
+import { faker } from '@faker-js/faker';
+
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
@@ -17,6 +19,7 @@ const header = new Header();
 
 describe('US_01.004 | FreestyleProject > Delete Project', () => {
 
+    const randomItemName = faker.lorem.words();
     let project = genData.newProject();
 
     it("TC_01.004.05 | Cancel deletion", () => {
@@ -34,7 +37,27 @@ describe('US_01.004 | FreestyleProject > Delete Project', () => {
         dashboardPage.getAllJobNames().should('have.text', newJobPageData.projectName)
       });
 
-      it("TC_01.004.11 | Verify user is able to cancel project deleting", () => {
+      it('TC_01.004.10 | Verify Freestyle Project is deleted from Dashboard page', () => {
+
+        cy.log('Creating Freestyle project');
+        dashboardPage.clickNewItemMenuLink();
+        newJobPage.typeNewItemName(randomItemName)
+                  .selectFreestyleProject()
+                  .clickOKButton();
+        freestyleProjectPage.clickSaveButton();
+        header.clickJenkinsLogo();  
+        cy.log('Deleting Freestyle project');
+        dashboardPage.hoverJobTitleLink()
+                     .clickJobTableDropdownChevron()
+                     .clickDeleteProjectDropdownMenuItem()
+                     .clickSubmitDeletingButton();
+
+        cy.log('Verifying Freestyle Project is deleted from Dashboard page');
+        dashboardPage.getMainPanel().contains(randomItemName).should('not.exist')
+        dashboardPage.getWelcomeToJenkins().should('be.visible');
+      })
+
+      it('TC_01.004.11 | Verify user is able to cancel project deleting', () => {
         dashboardPage.clickNewItemMenuLink();
         newJobPage.typeNewItemName(project.name)
                   .selectFreestyleProject()

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -13,10 +13,13 @@ class DashboardPage {
   getManageJenkins = () => cy.get('a[href="/manage"]');
   getProjectName = () => cy.get('*.jenkins-table__link span');
   getProjectChevronIcon = (projectName) => cy.get(`span:contains('${projectName}') + .jenkins-menu-dropdown-chevron`);
+  getJobTableDropdownChevron = () => cy.get('.jenkins-table__link > .jenkins-menu-dropdown-chevron');
+  getJobTableDropdownItem = () => cy.get('.jenkins-dropdown__item ');
   getAllJobNames = () => cy.get('.jenkins-table__link span')
   getDeleteProjectDropdownMenuItem = () => cy.get('button.jenkins-dropdown__item ').contains('Delete Project');
   getCancelProjectDeletingButton = () => cy.get('button[data-id="cancel"]');
-  getSubmitProjectDeletingButton = () => cy.get('button[data-id="ok"]')
+  getSubmitProjectDeletingButton = () => cy.get('button[data-id="ok"]');
+  getWelcomeToJenkins = () => cy.get('.empty-state-block h1');
 
 
 
@@ -61,6 +64,11 @@ class DashboardPage {
     return this
   }
 
+  clickJobTableDropdownChevron() {
+    this.getJobTableDropdownChevron().click({ force: true })
+    return this
+  }
+
   clickDeleteProjectDropdownMenuItem() {
     this.getDeleteProjectDropdownMenuItem().click()
     return this
@@ -71,6 +79,10 @@ class DashboardPage {
     return this;
   }
 
+  clickSubmitDeletingButton() {
+    this.getSubmitProjectDeletingButton().click()
+    return this
+  }
 };
 
 export default DashboardPage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to 'freestyleProjectDeleteProjectPOM.cy.js':
- Added the import statement for 'faker' library;
- Added a variable randomItemName for 'faker' further usage;

2. Made changes to 'DashboardPage.js':
- Added locators: 'getJobTableDropdownChevron', 'getJobTableDropdownItem', 'getWelcomeToJenkins';
- Added method:s 'clickJobTableDropdownChevron()', 'clickSubmitDeletingButton()' ;

3. Converted TC_01.004.10 to POM format
The test passed. 
![TC_01 004 10  Verify Freestyle Project is deleted from Dashboard page](https://github.com/user-attachments/assets/765ed51f-912f-4248-af3d-ae48fe03fac2)

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/448
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/22