### PR TITLE
RF_00.002.02 | New Item > Create Pipeline Project | Pipeline item type is highlighted when selected

### DIFF
--- a/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
+++ b/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import { faker } from '@faker-js/faker';
 
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
@@ -13,6 +14,8 @@ const {projectNameInvalid, errorMessageColor} = allKeys;
 
 describe("US_00.002 | New Item > Create Pipeline Project", () => {
 
+  const randomItemName = faker.commerce.productName();
+
   it("TC_00.002.01 | Special characters are not allowed in the project name", () => {
     dashboardPage
       .clickNewItemMenuLink()
@@ -22,4 +25,14 @@ describe("US_00.002 | New Item > Create Pipeline Project", () => {
       .and("have.css", "color", errorMessageColor);
   });
 
+  it('TC_00.002.02 | Pipeline item type is highlighted when selected ', () => {
+
+    dashboardPage
+        .clickNewItemMenuLink()
+        .typeNewItemName(randomItemName)
+        .selectPipelineProject()
+
+    newJobPage.getPipelineSelectedState()
+        .should('have.attr', 'aria-checked', 'true')
+  });
 });

--- a/cypress/pageObjects/NewJobPage.js
+++ b/cypress/pageObjects/NewJobPage.js
@@ -4,6 +4,8 @@ class NewJobPage {
 
     getJobNameField = () => cy.get('#name');
     getFreeStlPrjType = () => cy.get('.label').contains('Freestyle project');
+    getPipelineType = () => cy.get('span.label').contains('Pipeline');
+    getPipelineSelectedState = () => cy.get('.org_jenkinsci_plugins_workflow_job_WorkflowJob');
     getOKButton = () => cy.get('#ok-button');
     getItemNameInvalidErrorMessage = () => cy.get("#itemname-invalid");
     getUnsaveItemInvalidName = () => cy.get("#itemname-invalid").contains(/is an unsafe character/);
@@ -17,6 +19,11 @@ class NewJobPage {
 
     selectFreestyleProject () {
         this.getFreeStlPrjType().click();
+        return this;
+    }
+
+    selectPipelineProject () {
+        this.getPipelineType().click();
         return this;
     }
 

--- a/cypress/pageObjects/NewJobPage.js
+++ b/cypress/pageObjects/NewJobPage.js
@@ -4,7 +4,7 @@ class NewJobPage {
 
     getJobNameField = () => cy.get('#name');
     getFreeStlPrjType = () => cy.get('.label').contains('Freestyle project');
-    getPipelineType = () => cy.get('span.label').contains('Pipeline');
+    getPipelinePrjType = () => cy.get('span.label').contains('Pipeline');
     getPipelineSelectedState = () => cy.get('.org_jenkinsci_plugins_workflow_job_WorkflowJob');
     getOKButton = () => cy.get('#ok-button');
     getItemNameInvalidErrorMessage = () => cy.get("#itemname-invalid");
@@ -23,7 +23,7 @@ class NewJobPage {
     }
 
     selectPipelineProject () {
-        this.getPipelineType().click();
+        this.getPipelinePrjType().click();
         return this;
     }
 


### PR DESCRIPTION
[RF_00.002-02 | New Item > Create Pipeline Project | Pipeline item type is highlighted when selected](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/449)

In this PR:

1. Imported faker to use for random project name generation in **newItemCreatePipelineProjectPOM.cy.js**
2. created new const to hold the folder name `const randomItemName = faker.commerce.productName();` 
3. added new locator `getPipelineType = () => cy.get('span.label').contains('Pipeline');` to **NewJobPage**
4. added a method `selectPipelineProject () {
        this.getPipelineType().click();
        return this;
    }`
5. added selector for pipeline type selected state `getPipelineSelectedState = () => cy.get('.org_jenkinsci_plugins_workflow_job_WorkflowJob');`



____

**Description:**
As a registered user, I want to select a new item with the item type "Pipeline" 

**Acceptance Criteria**

The pipeline is selected after the user clicks on it

**Steps**

1. From the Jenkins dashboard click on New Item on the left sidebar
2. Enter a valid item name
3. Click on **Pipeline**


**Expected result**
- User can select item type
- Pipeline is highlighted as the chosen item type
