### PR TITLE
RF_01.002.06 | FreestyleProject > Rename Project | Rename a project name from the Dashboard

### DIFF
--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -1,0 +1,32 @@
+/// <reference types="cypress" />
+
+import DashboardPage from "../pageObjects/DashboardPage";
+import NewJobPage from "../pageObjects/NewJobPage";
+import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
+
+import { faker } from '@faker-js/faker';
+
+const dashboardPage = new DashboardPage();
+const newJobPage = new NewJobPage();
+const freestyleProjectPage = new FreestyleProjectPage();
+
+describe("US_01.002 | FreestyleProject > Rename Project", () => {
+    const initialProjectName = faker.lorem.words(); 
+    const renamedProjectName = faker.lorem.words();
+    
+    it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
+        
+        dashboardPage.clickNewItemMenuLink ()
+        newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject()
+        newJobPage.clickOKButton ()
+        freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink()
+
+        dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem()
+        freestyleProjectPage.getRenameField().click()
+        freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName)
+        freestyleProjectPage.clickRenameButton()
+        freestyleProjectPage.getPageHeadline().should('have.text', renamedProjectName)
+   })
+
+
+})

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
 
-import DashboardPage from "../pageObjects/DashboardPage";
-import NewJobPage from "../pageObjects/NewJobPage";
-import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
+import DashboardPage from '../pageObjects/DashboardPage';
+import NewJobPage from '../pageObjects/NewJobPage';
+import FreestyleProjectPage from '../pageObjects/FreestyleProjectPage';
 
 import { faker } from '@faker-js/faker';
 
@@ -16,17 +16,15 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
     
     it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
         
-        dashboardPage.clickNewItemMenuLink ()
-        newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject()
-        newJobPage.clickOKButton ()
-        freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink()
+        dashboardPage.clickNewItemMenuLink();
+        newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
+        newJobPage.clickOKButton();
+        freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
 
-        dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem()
-        freestyleProjectPage.getRenameField().click()
-        freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName)
-        freestyleProjectPage.clickRenameButton()
-        freestyleProjectPage.getPageHeadline().should('have.text', renamedProjectName)
+        dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
+        freestyleProjectPage.getRenameField().click();
+        freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
+        freestyleProjectPage.clickRenameButton();
+        freestyleProjectPage.getPageHeadline().should('have.text', renamedProjectName);
    })
-
-
 })

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -27,7 +27,7 @@ class DashboardPage {
   getWelcomeToJenkinsHeadline = () => cy.get('.empty-state-block h1');
   getWelcomeToJenkins = () => cy.get('.empty-state-block h1');
   getJobHeadline = () => cy.get('#main-panel h1');
-
+  getRenameProjectDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item').contains('Rename')
   hoverDashboardDropdownChevron() {
     this.getDashboardBreadcrumb().realHover()
     return this
@@ -121,6 +121,11 @@ class DashboardPage {
   clickDeleteOrganizationFolderDropdownMenuItem() {
     this.getDeleteOrganizationFolderDropdownMenuItem().click();
     return this;
+  }
+
+  clickRenameProjectDropdownMenuItem() {
+    this.getRenameProjectDropdownMenuItem().click()
+    return this
   }
 
 };

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -17,6 +17,9 @@ class FreestyleProjectPage {
     getDashboardLink = () => cy.get('a[href="/"].model-link');
     getDeleteMenuItem = () => cy.get('a[data-title="Delete Project"]');
     getCancelButton = () => cy.get('button[data-id="cancel"]');
+    getRenameField = () => cy.get('input.jenkins-input')
+    getRenameButton = () => cy.get('button.jenkins-submit-button')
+    getPageHeadline = () => cy.get('h1.job-index-headline')
 
     clickSaveButton() {
         this.getSaveButton().click();
@@ -68,6 +71,17 @@ class FreestyleProjectPage {
         return this;
     }
 
+    clearRenameField() {
+        this.getRenameField().clear()
+        return this
+    }
+    typeRenameField(ProjectName) {
+        this.getRenameField().type(ProjectName)
+    }
+
+    clickRenameButton() {
+        this.getRenameButton().click()
+    }
 }
 
 export default FreestyleProjectPage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to 'DashboardPage.js':
Added locator: getRenameProjectDropdownMenuItem
Added method: clickRenameProjectDropdownMenuItem
Made changes to 'FreestyleProjectPage.js':
Added locators: getRenameField, getRenameButton, getPageHeadline
Added methods: clearRenameField, typeRenameField, clickRenameButton

2. Converted TC_01.002.06 to POM format

[TC_01.002.06](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/255)
[US_01.002](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/21)