### PR TITLE
RF_01.002.06 | FreestyleProject > Rename Project | Rename a project name from the Dashboard

### DIFF
--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -13,6 +13,8 @@ const newJobPage = new NewJobPage();
 const freestyleProjectPage = new FreestyleProjectPage();
 
 describe("US_01.002 | FreestyleProject > Rename Project", () => {
+  const initialProjectName = faker.lorem.words(); 
+  const renamedProjectName = faker.lorem.words();
   let project = genData.newProject();
   it("TC_01.002.02 | Rename a project from the Project Page", () => {
     dashboardPage.clickNewItemMenuLink();
@@ -34,8 +36,6 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
   });
     
   it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
-    const initialProjectName = faker.lorem.words(); 
-    const renamedProjectName = faker.lorem.words();
     
     dashboardPage.clickNewItemMenuLink();
     newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
@@ -43,9 +43,9 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
     freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
 
     dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
-    freestyleProjectPage.getRenameField().click();
+    freestyleProjectPage.getNewNameField().click();
     freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
     freestyleProjectPage.clickRenameButtonSubmit();
-    freestyleProjectPage.getPageHeadline().should('have.text', renamedProjectName);
+    freestyleProjectPage.getJobHeadline().should('have.text', renamedProjectName);
    })
 });

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -4,6 +4,8 @@ import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
 
+import { faker } from '@faker-js/faker';
+
 import genData from "../fixtures/genData"
 
 const dashboardPage = new DashboardPage();
@@ -30,4 +32,20 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
 
     dashboardPage.getJobTitleLink().should("have.text", project.newName);
   });
+    
+  it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
+    const initialProjectName = faker.lorem.words(); 
+    const renamedProjectName = faker.lorem.words();
+    
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
+    newJobPage.clickOKButton();
+    freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
+
+    dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
+    freestyleProjectPage.getRenameField().click();
+    freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
+    freestyleProjectPage.clickRenameButtonSubmit();
+    freestyleProjectPage.getPageHeadline().should('have.text', renamedProjectName);
+   })
 });

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -27,6 +27,7 @@ class DashboardPage {
   getWelcomeToJenkinsHeadline = () => cy.get('.empty-state-block h1');
   getWelcomeToJenkins = () => cy.get('.empty-state-block h1');
   getJobHeadline = () => cy.get('#main-panel h1');
+  getRenameProjectDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item').contains('Rename');
 
   hoverDashboardDropdownChevron() {
     this.getDashboardBreadcrumb().realHover()
@@ -125,6 +126,11 @@ class DashboardPage {
 
   clickCreateJobLink() {
     this.getCreateJobButton().click();
+    return this;
+  }
+
+  clickRenameProjectDropdownMenuItem() {
+    this.getRenameProjectDropdownMenuItem().click();
     return this;
   }
 

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -19,6 +19,10 @@ class FreestyleProjectPage {
     getCancelButton = () => cy.get('button[data-id="cancel"]');
     getRenameButton = () => cy.get('[href*="rename"]');
     getNewNameField = () => cy.get('[name="newName"]');
+    getRenameField = () => cy.get('input.jenkins-input');
+    getRenameButtonSubmit = () => cy.get('button.jenkins-submit-button');
+    getPageHeadline = () => cy.get('h1.job-index-headline');
+
 
     clickSaveButton() {
         this.getSaveButton().click();
@@ -79,6 +83,22 @@ class FreestyleProjectPage {
         this.getNewNameField().clear().type(projectNewName);
         return this;
     }
+
+    clearRenameField() {
+        this.getRenameField().clear();
+        return this;
+    }
+    typeRenameField(ProjectName) {
+        this.getRenameField().type(ProjectName);
+        return this;
+    }
+
+    clickRenameButtonSubmit() {
+        this.getRenameButtonSubmit().click();
+        return this;
+    }
+
+
 }
 
 export default FreestyleProjectPage;

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -19,9 +19,7 @@ class FreestyleProjectPage {
     getCancelButton = () => cy.get('button[data-id="cancel"]');
     getRenameButton = () => cy.get('[href*="rename"]');
     getNewNameField = () => cy.get('[name="newName"]');
-    getRenameField = () => cy.get('input.jenkins-input');
     getRenameButtonSubmit = () => cy.get('button.jenkins-submit-button');
-    getPageHeadline = () => cy.get('h1.job-index-headline');
 
 
     clickSaveButton() {
@@ -85,11 +83,11 @@ class FreestyleProjectPage {
     }
 
     clearRenameField() {
-        this.getRenameField().clear();
+        this.getNewNameField().clear();
         return this;
     }
     typeRenameField(ProjectName) {
-        this.getRenameField().type(ProjectName);
+        this.getNewNameField().type(ProjectName);
         return this;
     }
 
@@ -97,8 +95,6 @@ class FreestyleProjectPage {
         this.getRenameButtonSubmit().click();
         return this;
     }
-
-
 }
 
 export default FreestyleProjectPage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to 'DashboardPage.js':
Added locator: getRenameProjectDropdownMenuItem
Added method: clickRenameProjectDropdownMenuItem
Made changes to 'FreestyleProjectPage.js':
Added locators: getRenameButtonSubmit
Added methods: clearRenameField, typeRenameField, clickRenameButtonSubmit

2. Converted TC_01.002.06 to POM format

[TC_01.002.06](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/255)
[US_01.002](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/21)