### PR TITLE
change verifyFolderUrl method in FolderPage.js file

### DIFF
--- a/cypress/pageObjects/FolderPage.js
+++ b/cypress/pageObjects/FolderPage.js
@@ -9,7 +9,7 @@ class FolderPage extends Header {
     getDashboardBreadcrumbsLink = () => cy.get('#breadcrumbs a[href="/"]');
     getNewItemMenuOption = () => cy.get('[href $= "/newJob"]');
     getNewNameField = () => cy.get('input[name="newName"]')
-    getFolderUrl = () => cy.url()
+    getFolderUrl = () => cy.url({ decode: true })
 
     clickSaveBtn () {
         this.getSaveBtn().click();
@@ -43,7 +43,7 @@ class FolderPage extends Header {
     }   
 
     verifyFolderUrl(folderName) {
-        this.getFolderUrl().should('include', `/${folderName}`)
+        this.getFolderUrl().should('contain', folderName)
     }
  
 };


### PR DESCRIPTION
**Implemented Changes:**

- replaced **getFolderUrl = () => cy.url({ decode: true })**
- changed **verifyFolderUrl(**) method

Рassed the test locally:
![u49X6I5pFp](https://github.com/user-attachments/assets/af419aad-b96a-4d27-8e31-c9e23fc887ec)
![image](https://github.com/user-attachments/assets/c5474602-538a-4ddd-9786-a5adc4b62447)


