### PR TITLE
TC_00.002.15-A | New Item > Create Pipeline Project | The URL of the configure page contains new project name

### DIFF
--- a/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
+++ b/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
@@ -88,4 +88,15 @@ describe("US_00.002 | New Item > Create Pipeline Project", () => {
       .and('be.visible');
   });
 
+  it('TC_00.002.15 | The url of the configure page contains new project name', () => {
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage
+      .typeNewItemName(project.name)
+      .selectPipelineProject()
+      .clickOKButton()
+
+      .getBreadcrumbsListItem().should('have.text', 'Configuration')
+    newJobPage  
+      .getUrlConfigurePageField().should('include', project.name)
+  })
 });

--- a/cypress/pageObjects/NewJobPage.js
+++ b/cypress/pageObjects/NewJobPage.js
@@ -13,6 +13,8 @@ class NewJobPage {
     getFolferType = () => cy.get('.label').contains('Folder');
     getOrganizationFolderType = () => cy.get('[class="jenkins_branch_OrganizationFolder"]');
     getSaveButton = () => cy.get('button[name="Submit"]');
+    getUrlConfigurePageField = () => cy.location('href');
+    getBreadcrumbsListItem = () => cy.get("[aria-current='page']");
   
 
     typeNewItemName (prjName) {


### PR DESCRIPTION
[TC_00.002.15](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/516) | New Item > Create Pipeline Project | The URL of the configure page contains new project name

**Implemented Changes:**

This is newly created TC ( not refactoring) in POM format.

to **NewJobPage:**

- added locator getUrlConfigurePageField
- added locator getBreadcrumbsListItem