### PR TITLE
RF_01.002.10 | Receive an Error when the new name is invalid

### DIFF
--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -3,34 +3,19 @@
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
-import Header from "../pageObjects/Header";
 
 import { faker } from '@faker-js/faker';
+
 import genData from "../fixtures/genData"
 
 const dashboardPage = new DashboardPage();
 const newJobPage = new NewJobPage();
 const freestyleProjectPage = new FreestyleProjectPage();
-const header = new Header();
-
 
 describe("US_01.002 | FreestyleProject > Rename Project", () => {
-
+  const initialProjectName = faker.lorem.words(); 
   const renamedProjectName = faker.lorem.words();
   let project = genData.newProject();
-
-  beforeEach(() => {
-    dashboardPage.clickNewItemMenuLink();
-    newJobPage
-        .typeNewItemName(project.name)
-        .selectFreestyleProject()
-        .clickOKButton()
-    freestyleProjectPage
-        .typeJobDescription(project.description)
-        .clickSaveButton();
-    header.clickJenkinsLogo()
-  });
-
   it.skip("TC_01.002.02 | Rename a project from the Project Page", () => {
     dashboardPage.clickNewItemMenuLink();
     newJobPage
@@ -49,23 +34,48 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
 
     dashboardPage.getJobTitleLink().should("have.text", project.newName);
   });
-    
+  
   it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
+    
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
+    newJobPage.clickOKButton();
+    freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
 
     dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
     freestyleProjectPage.getNewNameField().click();
     freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
     freestyleProjectPage.clickRenameButtonSubmit();
     freestyleProjectPage.getJobHeadline().should('have.text', renamedProjectName);
-   })
+  })
 
-  it('TC_01.002.10 | Receive an Error when the new name is invalid', () => {
-
+  it("TC_01.002.04 | Rename a project name from the Dashboard page", () => {
+    //Preconditions, Create new item nameJob
     dashboardPage
-        .openDropdownForProject(project.name)
-        .clickRenameFolderDropdownMenuItem()
-
+        .clickNewItemMenuLink();
+    newJobPage
+        .typeNewItemName(project.name)
+        .selectFreestyleProject()
+        .clickOKButton();
     freestyleProjectPage
-        .validateSpecialCharacters()
+        .clickSaveButton()
+        .clickDashboardBreadcrumbsLink();
+    //Navigate drop-down menu
+    dashboardPage
+        .clickJobTableDropdownChevron()
+        .clickRenameProjectDropdownMenuItem();
+    //Rename job
+    freestyleProjectPage
+      .typeNewName(project.newName)
+      .clickSaveButton();
+    //Checks
+    freestyleProjectPage
+        .getJobHeadline().should('contain', project.newName)
+    freestyleProjectPage
+        .clickDashboardBreadcrumbsLink();
+    dashboardPage
+        .getJobTitleLink()
+        .should("contain", project.newName);
     });
+    
 });

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -3,19 +3,19 @@
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
-
-import { faker } from '@faker-js/faker';
+import Header from "../pageObjects/Header";
 
 import genData from "../fixtures/genData"
 
 const dashboardPage = new DashboardPage();
 const newJobPage = new NewJobPage();
 const freestyleProjectPage = new FreestyleProjectPage();
+const header = new Header();
 
 describe("US_01.002 | FreestyleProject > Rename Project", () => {
-  const initialProjectName = faker.lorem.words(); 
-  const renamedProjectName = faker.lorem.words();
+
   let project = genData.newProject();
+
   it.skip("TC_01.002.02 | Rename a project from the Project Page", () => {
     dashboardPage.clickNewItemMenuLink();
     newJobPage
@@ -38,15 +38,15 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
   it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
     
     dashboardPage.clickNewItemMenuLink();
-    newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
+    newJobPage.typeNewItemName(project.name).selectFreestyleProject();
     newJobPage.clickOKButton();
     freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
 
     dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
     freestyleProjectPage.getNewNameField().click();
-    freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
+    freestyleProjectPage.clearRenameField().typeRenameField(project.newName);
     freestyleProjectPage.clickRenameButtonSubmit();
-    freestyleProjectPage.getJobHeadline().should('have.text', renamedProjectName);
+    freestyleProjectPage.getJobHeadline().should('have.text', project.newName);
   })
 
   it("TC_01.002.04 | Rename a project name from the Dashboard page", () => {
@@ -77,5 +77,28 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
         .getJobTitleLink()
         .should("contain", project.newName);
     });
+
+  it('TC_01.002.10 | Receive an Error when the new name is invalid', () => {
+
+    cy.log("Creating Freestyle Project");
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage
+        .typeNewItemName(project.name)
+        .selectFreestyleProject()
+        .clickOKButton()
+    freestyleProjectPage
+        .typeJobDescription(project.description)
+        .clickSaveButton();
+    header.clickJenkinsLogo()
+
+    cy.log("Steps")
+    dashboardPage
+        .openDropdownForProject(project.name)
+
+    dashboardPage.clickRenameFolderDropdownMenuItem()
+
+    freestyleProjectPage
+        .validateSpecialCharacters()
+  });
     
 });

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -3,19 +3,34 @@
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from "../pageObjects/FreestyleProjectPage";
+import Header from "../pageObjects/Header";
 
 import { faker } from '@faker-js/faker';
-
 import genData from "../fixtures/genData"
 
 const dashboardPage = new DashboardPage();
 const newJobPage = new NewJobPage();
 const freestyleProjectPage = new FreestyleProjectPage();
+const header = new Header();
+
 
 describe("US_01.002 | FreestyleProject > Rename Project", () => {
-  const initialProjectName = faker.lorem.words(); 
+
   const renamedProjectName = faker.lorem.words();
   let project = genData.newProject();
+
+  beforeEach(() => {
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage
+        .typeNewItemName(project.name)
+        .selectFreestyleProject()
+        .clickOKButton()
+    freestyleProjectPage
+        .typeJobDescription(project.description)
+        .clickSaveButton();
+    header.clickJenkinsLogo()
+  });
+
   it.skip("TC_01.002.02 | Rename a project from the Project Page", () => {
     dashboardPage.clickNewItemMenuLink();
     newJobPage
@@ -34,48 +49,23 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
 
     dashboardPage.getJobTitleLink().should("have.text", project.newName);
   });
-  
-  it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
     
-    dashboardPage.clickNewItemMenuLink();
-    newJobPage.typeNewItemName(initialProjectName).selectFreestyleProject();
-    newJobPage.clickOKButton();
-    freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
+  it('TC-01.002.06| Rename a project name from the Dashboard page', () => {
 
     dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
     freestyleProjectPage.getNewNameField().click();
     freestyleProjectPage.clearRenameField().typeRenameField(renamedProjectName);
     freestyleProjectPage.clickRenameButtonSubmit();
     freestyleProjectPage.getJobHeadline().should('have.text', renamedProjectName);
-  })
+   })
 
-  it("TC_01.002.04 | Rename a project name from the Dashboard page", () => {
-    //Preconditions, Create new item nameJob
+  it('TC_01.002.10 | Receive an Error when the new name is invalid', () => {
+
     dashboardPage
-        .clickNewItemMenuLink();
-    newJobPage
-        .typeNewItemName(project.name)
-        .selectFreestyleProject()
-        .clickOKButton();
+        .openDropdownForProject(project.name)
+        .clickRenameFolderDropdownMenuItem()
+
     freestyleProjectPage
-        .clickSaveButton()
-        .clickDashboardBreadcrumbsLink();
-    //Navigate drop-down menu
-    dashboardPage
-        .clickJobTableDropdownChevron()
-        .clickRenameProjectDropdownMenuItem();
-    //Rename job
-    freestyleProjectPage
-      .typeNewName(project.newName)
-      .clickSaveButton();
-    //Checks
-    freestyleProjectPage
-        .getJobHeadline().should('contain', project.newName)
-    freestyleProjectPage
-        .clickDashboardBreadcrumbsLink();
-    dashboardPage
-        .getJobTitleLink()
-        .should("contain", project.newName);
+        .validateSpecialCharacters()
     });
-    
 });

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -22,8 +22,7 @@ class FreestyleProjectPage {
     getNewNameField = () => cy.get('[name="newName"]');
     getRenameButtonSubmit = () => cy.get('button.jenkins-submit-button');
     getBreadcrumbBar = () => cy.get('#breadcrumbBar');
-    getHeaderOnRename = () => cy.get("div h1")
-    getErrorMessageParagraph = () => cy.get('p')
+
 
     clickSaveButton() {
         this.getSaveButton().click();
@@ -103,25 +102,6 @@ class FreestyleProjectPage {
         this.getRenameButtonSubmit().click();
         return this;
     }
-
-    validateSpecialCharacters() {
-        const specialChars = `!@#$%^*|[]\\:;\?/`.split("");
-
-        specialChars.forEach((char) => {
-            // Clear, type the new name, and click Save
-            this.getNewNameField().clear().type(`Rename${char}Folder`);
-            this.getSaveButton().click();
-
-            // Assertions for error messages
-            this.getHeaderOnRename().should("have.text", "Error");
-            this.getErrorMessageParagraph().should(
-                "have.text",
-                `‘${char}’ is an unsafe character`
-            );
-
-            // Navigate back to retry the next character
-            cy.go("back");
-        });
-    }
 }
+
 export default FreestyleProjectPage;

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -23,6 +23,8 @@ class FreestyleProjectPage {
     getRenameButtonSubmit = () => cy.get('button.jenkins-submit-button');
     getBreadcrumbBar = () => cy.get('#breadcrumbBar');
 
+    getHeaderOnRename = () => cy.get("div h1")
+    getErrorMessageParagraph = () => cy.get('p')
 
     clickSaveButton() {
         this.getSaveButton().click();
@@ -102,6 +104,24 @@ class FreestyleProjectPage {
         this.getRenameButtonSubmit().click();
         return this;
     }
-}
 
+    validateSpecialCharacters() {
+        const specialChars = `!@#$%^*`.split("");
+
+        specialChars.forEach((char) => {
+            // Clear, type the new name, and click Save
+            this.getNewNameField().clear().type(`Rename${char}Folder`);
+            this.getSaveButton().click();
+
+            // Assertions for error messages
+            this.getHeaderOnRename().should("have.text", "Error");
+            this.getErrorMessageParagraph().should(
+                "have.text",
+                `‘${char}’ is an unsafe character`
+            );
+            // Navigate back to retry the next character
+            cy.go("back");
+        });
+    }
+}
 export default FreestyleProjectPage;

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -22,7 +22,8 @@ class FreestyleProjectPage {
     getNewNameField = () => cy.get('[name="newName"]');
     getRenameButtonSubmit = () => cy.get('button.jenkins-submit-button');
     getBreadcrumbBar = () => cy.get('#breadcrumbBar');
-
+    getHeaderOnRename = () => cy.get("div h1")
+    getErrorMessageParagraph = () => cy.get('p')
 
     clickSaveButton() {
         this.getSaveButton().click();
@@ -102,6 +103,25 @@ class FreestyleProjectPage {
         this.getRenameButtonSubmit().click();
         return this;
     }
-}
 
+    validateSpecialCharacters() {
+        const specialChars = `!@#$%^*|[]\\:;\?/`.split("");
+
+        specialChars.forEach((char) => {
+            // Clear, type the new name, and click Save
+            this.getNewNameField().clear().type(`Rename${char}Folder`);
+            this.getSaveButton().click();
+
+            // Assertions for error messages
+            this.getHeaderOnRename().should("have.text", "Error");
+            this.getErrorMessageParagraph().should(
+                "have.text",
+                `‘${char}’ is an unsafe character`
+            );
+
+            // Navigate back to retry the next character
+            cy.go("back");
+        });
+    }
+}
 export default FreestyleProjectPage;


### PR DESCRIPTION
[RF_01.002.10 | FreestyleProject > Rename Project | Receive an Error when the new name is invalid](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/522)

In **freestyleProjectRenameProjectPOM.cy.js**:

1. imported `Header from "../pageObjects/Header";`
2. created `const header = new Header(); `
3. removed unused variables
4. Added TC_01.002.10 
5. Removed faker import as the tests use genData.js


In **FreestyleProjectPage.js**
1. added `validateSpecialCharacters` method that iterates though invalid characters - for this one I'm not sure if having the characters inside the method is good enough or maybe changing and getting the characters from a fixture file would be better
2. added     `getHeaderOnRename = () => cy.get("div h1")` - locator that get the header on the error page
3. added     `getErrorMessageParagraph = () => cy.get('p')` - locator that get the text from the error page


____

**Description:**
As a registered user,
I want to update a project name,
so that I can meet the company's naming requirements and ensure accurate project identification.

**Precondition:** 
we should have a project before the updating a project name.

**Steps**
1. Open project from Dashboard page
2. Click Rename from side navigation
3. Enter a invalid name

**Expected**
Error message stating new name is invalid

**Acceptance criteria:**
Receive an Error when the new name is invalid