### PR TITLE
RF_01.004.14 | FreestyleProject > Delete Project | Verify Freestyle Project is deleted from Project page

### DIFF
--- a/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
@@ -53,7 +53,7 @@ describe('US_01.004 | FreestyleProject > Delete Project', () => {
                      .clickSubmitDeletingButton();
 
         cy.log('Verifying Freestyle Project is deleted from Dashboard page');
-        dashboardPage.getMainPanel().contains(randomItemName).should('not.exist')
+        dashboardPage.getMainPanel().contains(project.name).should('not.exist')
         dashboardPage.getWelcomeToJenkinsHeadline().should('be.visible');
       })
 
@@ -68,7 +68,18 @@ describe('US_01.004 | FreestyleProject > Delete Project', () => {
           .getProjectName()
           .should("have.text", project.name)
           .and("be.visible");
-      }); 
+      });
+      
+      it('TC_01.004.14 | Verify Freestyle Project is deleted from Project page', () => {
+
+        dashboardPage.clickJobTitleLink();
+        freestyleProjectPage.getJobHeadline().should('be.visible').and('have.text', project.name);
+        freestyleProjectPage.clickDeleteMenuItem()
+                            .clickYesButton();
+
+        dashboardPage.getMainPanel().should('not.contain.value', project.name);
+        dashboardPage.getWelcomeToJenkinsHeadline().should('be.visible');
+    })
 
       it('TC_01.004.04 | FreestyleProject > Delete Project|Delete a project from the Project Page', () => {
         //Create a project

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -25,7 +25,6 @@ class DashboardPage {
   getCancelProjectDeletingButton = () => cy.get('button[data-id="cancel"]');
   getSubmitProjectDeletingButton = () => cy.get('button[data-id="ok"]');
   getWelcomeToJenkinsHeadline = () => cy.get('.empty-state-block h1');
-  getWelcomeToJenkins = () => cy.get('.empty-state-block h1');
   getJobHeadline = () => cy.get('#main-panel h1');
   getRenameFolderDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item ').contains('Rename');
   getRenameProjectDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item').contains('Rename');


### PR DESCRIPTION
Implemented Changes:
- Deleted the unnecessary getter `getWelcomeToJenkins` from `DashboardPage.js,` cause such a getter already exists (`getWelcomeToJenkinsHeadline`)
- Converted TC_01.004.14 to POM format.

Link to Github board card: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/562
Link to US: https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/22