### PR TITLE
TC_04.004.04 | Folder > Add or Edit Description of a Folder | Enter a long text in the description field

### DIFF
--- a/cypress/e2e/folderAddOrEditDescriptionOfAFolderPOM.cy.js
+++ b/cypress/e2e/folderAddOrEditDescriptionOfAFolderPOM.cy.js
@@ -1,0 +1,27 @@
+/// <reference types="cypress"/>
+
+import DashboardPage from '../pageObjects/DashboardPage';
+import NewJobPage from '../pageObjects/NewJobPage';
+import FolderPage from '../pageObjects/FolderPage.js';
+import genData from "../fixtures/genData";
+
+const dashboardPage = new DashboardPage();
+const newJobPage = new NewJobPage();
+const folderPage = new FolderPage();
+let folder = genData.newProject();
+
+describe("US_04.004 | Folder > Add or Edit Description of a Folder", () => {
+
+    it("TC_04.004.04 | Enter a long text in the description field", () => {
+
+        dashboardPage.clickNewItemMenuLink();
+        newJobPage.typeNewItemName(folder.name)
+            .selectFolder()
+            .clickOKButton();
+        folderPage.typeDescription(folder.longDescription)
+            .clickSaveBtn()
+
+            .getFolderDescription().should('be.visible')
+            .and('have.text', folder.longDescription);
+    });
+})

--- a/cypress/fixtures/genData.js
+++ b/cypress/fixtures/genData.js
@@ -7,7 +7,8 @@ module.exports = {
             newName: faker.company.buzzNoun(),
             description: faker.lorem.sentences(3),
             newDescription: faker.lorem.sentences(2),
-            folderName: faker.company.buzzNoun()
+            folderName: faker.company.buzzNoun(),
+            longDescription: faker.lorem.sentences(50)
         };
         return Project;
     },

--- a/cypress/pageObjects/FolderPage.js
+++ b/cypress/pageObjects/FolderPage.js
@@ -14,6 +14,8 @@ class FolderPage extends Header {
     getFolderUrl = () => cy.url({ decode: true });
     getProjectName = () => cy.get('*.jenkins-table__link span');
     getCreateAJobLink = () => cy.get('a[href="newJob"]');
+    getDescriptionField = () => cy.get('[name$="description"]');
+    getFolderDescription = () => cy.get('#view-message');
 
 
     clickSaveBtn () {
@@ -55,6 +57,11 @@ class FolderPage extends Header {
         this.getCreateAJobLink().click()
         return new NewJobPage();
     }
+
+    typeDescription (description) {
+        this.getDescriptionField().type(description);
+            return this;
+        };
  
 };
 


### PR DESCRIPTION
TC_04.004.04-A | Folder > Add or Edit Description of a Folder | Enter a long text in the description field
[#565](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/565)

In this PR:

1. Created folderAddOrEditDescriptionOfAFolderPOM.cy.js
2. To FolderPage.js:
    - added new locators: getDescriptionField  and getFolderDescription; 
    - added a method typeDescription
3. To genData.js:
    - added property longDescription