### PR TITLE
RF_01.002.07 | FreestyleProject > Rename Project | Verify duplicate names are rejected when renaming a project

### DIFF
--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -102,6 +102,7 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
   });
 
   it('TC_01.002.07 | Verify duplicate names are rejected when renaming a project', () => {
+
     dashboardPage.clickNewItemMenuLink();
     newJobPage.typeNewItemName(project.name).selectFreestyleProject();
     newJobPage.clickOKButton();
@@ -110,7 +111,7 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
     dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
     freestyleProjectPage.clickRenameButtonSubmit();
 
-    freestyleProjectPage.errorAssert();
+    freestyleProjectPage.assertRenameError();
 })
     
 });

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -100,5 +100,17 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
     freestyleProjectPage
         .validateSpecialCharacters()
   });
+
+  it('TC_01.002.07 | Verify duplicate names are rejected when renaming a project', () => {
+    dashboardPage.clickNewItemMenuLink();
+    newJobPage.typeNewItemName(project.name).selectFreestyleProject();
+    newJobPage.clickOKButton();
+    freestyleProjectPage.clickSaveButton().clickDashboardBreadcrumbsLink();
+
+    dashboardPage.clickJobTableDropdownChevron().clickRenameProjectDropdownMenuItem();
+    freestyleProjectPage.clickRenameButtonSubmit();
+
+    freestyleProjectPage.errorAssert();
+})
     
 });

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -130,7 +130,7 @@ class FreestyleProjectPage {
         });
     }
 
-    errorAssert() {
+    assertRenameError() {
         this.getHeaderOnRename().should('have.text', 'Error');
         this.getErrorMessageParagraph().should('have.text', 'The new name is the same as the current name.');
         return this;

--- a/cypress/pageObjects/FreestyleProjectPage.js
+++ b/cypress/pageObjects/FreestyleProjectPage.js
@@ -129,5 +129,11 @@ class FreestyleProjectPage {
             cy.go("back");
         });
     }
+
+    errorAssert() {
+        this.getHeaderOnRename().should('have.text', 'Error');
+        this.getErrorMessageParagraph().should('have.text', 'The new name is the same as the current name.');
+        return this;
+    }
 }
 export default FreestyleProjectPage;


### PR DESCRIPTION
Implemented Changes:

1. Rename TC from "Verify that duplicate names are not accepted when renaming a project from Project Page" to "Verify duplicate names are rejected when renaming a project"

2. **Made changes to 'FreestyleProjectPage.js':**
Added methods: errorAssert

3. Converted TC_01.002.07 to POM format

[TC_01.002.07](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/289)
[US_01.002](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/21)