### PR TITLE
RF_04.004.04 Added option to method in FolderPage.js

### DIFF
--- a/cypress/pageObjects/FolderPage.js
+++ b/cypress/pageObjects/FolderPage.js
@@ -59,7 +59,7 @@ class FolderPage extends Header {
     }
 
     typeDescription (description) {
-        this.getDescriptionField().type(description);
+        this.getDescriptionField().type(description, {delay: 0});
             return this;
         };
  


### PR DESCRIPTION
RF_04.004.04 | Folder > Add or Edit Description of a Folder | Enter a long text in the description field
[#583](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/583)

In FolderPage.js added: `{delay: 0}` to method typeDescription.
The `delay` option controls the interval between keystrokes. By default it is 10, so setting it to 0 means speeding up the test and CI when we enter text in the description, especially long text 