### PR TITLE
RF_04.001.02 | Folder > Rename Folder | Rename folder from drop-downmenu

### DIFF
--- a/cypress/e2e/folderRenameFolderPOM.cy.js
+++ b/cypress/e2e/folderRenameFolderPOM.cy.js
@@ -25,7 +25,7 @@ describe('US_04.001 | Folder > Rename Folder', () => {
     it('TC_04.001.02 | Rename folder from drop-down menu', () => {
 
         dashboardPage.openDropdownForItem(folderName.name)
-            .clickRenameFolderDropdownMenuItem()
+            .clickRenameDropdownOption()
         folderPage.clearNewNameField()
             .typeNewFolderName(newFolderName.name)
             .clickRenameButton()
@@ -37,7 +37,7 @@ describe('US_04.001 | Folder > Rename Folder', () => {
 
     it('TC_04.001.06 | Successfully enter a valid folder name in the special field', () => {
         dashboardPage.openDropdownForItem(folderName.name)
-            .clickRenameFolderDropdownMenuItem()
+            .clickRenameDropdownOption()
         folderPage.clearNewNameField()
             .typeNewFolderName(newFolderName.name)
             .getNewNameField().should('have.value', newFolderName.name)
@@ -45,7 +45,7 @@ describe('US_04.001 | Folder > Rename Folder', () => {
 
     it('TC_04.001.03| Verify that error message is displayed when an invalid folder name is entered in the Rename Folder field', () => {
         dashboardPage.openDropdownForItem(folderName.name)
-            .clickRenameFolderDropdownMenuItem()
+            .clickRenameDropdownOption()
         folderPage.clearNewNameField()
             .typeNewFolderName(newFolderName.name +"*")
             .clickRenameButton()

--- a/cypress/e2e/folderRenameFolderPOM.cy.js
+++ b/cypress/e2e/folderRenameFolderPOM.cy.js
@@ -17,22 +17,22 @@ describe('US_04.001 | Folder > Rename Folder', () => {
 
     beforeEach(() => {
         dashboardPage.clickNewItemMenuLink();
-        newJobPage.typeNewItemName(folderName.name).selectFolder().clickOKButton()
-        folderPage.clickSaveButton()
+        newJobPage.typeNewItemName(folderName.name).selectFolder().clickOKButton();
+        folderPage.clickSaveButton();
         header.clickJenkinsLogo();
     });
 
     it('TC_04.001.02 | Rename folder from drop-down menu', () => {
 
         dashboardPage.openDropdownForItem(folderName.name)
-            .clickRenameDropdownOption()
+            .clickRenameDropdownOption();
         folderPage.clearNewNameField()
             .typeNewFolderName(newFolderName.name)
-            .clickRenameButton()
-        folderPage.verifyFolderUrl(newFolderName.name)
+            .clickRenameButton();
+        folderPage.verifyFolderUrl(newFolderName.name);
 
         folderPage.getFolderNameOnMainPanel()
-            .should('include.text', `${newFolderName.name}`)
+            .should('include.text', `${newFolderName.name}`);
     });
 
     it('TC_04.001.06 | Successfully enter a valid folder name in the special field', () => {

--- a/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectRenameProjectPOM.cy.js
@@ -87,7 +87,7 @@ describe("US_01.002 | FreestyleProject > Rename Project", () => {
     cy.log("Steps");
     dashboardPage.openDropdownForItem(project.name);
 
-    dashboardPage.clickRenameFolderDropdownMenuItem();
+    dashboardPage.clickRenameDropdownOption();
 
     freestyleProjectPage.validateSpecialCharacters();
   });

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -18,7 +18,7 @@ class DashboardPage extends BasePage {
   getDeleteOrganizationFolderDropdownMenuItem = () => cy.get('[class="jenkins-dropdown__item "]').contains('Delete Organization Folder');
   getWelcomeToJenkinsHeadline = () => cy.get('.empty-state-block h1');
   getMoveTheProject = () => cy.get('a[href*="move"]');
-  getRenameFolderDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item ').contains('Rename');//please rename to getRenameDropdownOption
+  getRenameDropdownOption = () => cy.get('a.jenkins-dropdown__item ').contains('Rename');
   getRenameProjectDropdownMenuItem = () => cy.get('a.jenkins-dropdown__item').contains('Rename');//duplicate to getRenameFolderDropdownMenuItem, may be deleted
   getDeleteProjectDialogBox = () => cy.get('dialog.jenkins-dialog');
   getAllIconsProjectRow = (projectName) => cy.get(`tr[id$='${projectName}'] svg`);
@@ -103,8 +103,8 @@ class DashboardPage extends BasePage {
     return this;
   }
 
-  clickRenameFolderDropdownMenuItem() {//please rename to  clickRenameDropdownOption, so it can be reused
-    this.getRenameFolderDropdownMenuItem().click();
+  clickRenameDropdownOption() {
+    this.getRenameDropdownOption().click();
     return this
   }
 


### PR DESCRIPTION
**Implemented Changes:**

To 'DashboardPage.js':

renamed locator getRenameFolderDropdownMenuItem -> **getRenameDropdownOption**
renamed method clickRenameFolderDropdownMenuItem() -> **clickRenameDropdownOption**

replaced these methods in files **folderRenameFolderPOM.cy.js**, **freestyleProjectRenameProjectPOM.cy.js**

tests passed locally
![Cypress_ow2x2srUG7](https://github.com/user-attachments/assets/508a6160-5adc-4885-8c65-7c708c80479c)
![uoZrctgjQ2](https://github.com/user-attachments/assets/56182f7a-cdc5-4c72-8303-08d496e1a059)
