### PR TITLE
TC_02.004.04 | Pipeline > Pipeline Configuration | Verify the choice of the pipeline script directly in Jenkins, using the editor

### DIFF
--- a/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
+++ b/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
@@ -1,6 +1,7 @@
 /// <reference types="cypress"/>
 
 import { faker } from "@faker-js/faker";
+import genData from "../fixtures/genData";
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import PipelinePage from "../pageObjects/PipelinePage";
@@ -16,6 +17,7 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
   const randomItemName = faker.commerce.productName();
   const pipelineDescription = faker.lorem.paragraph();
   const newPipelineDescription = faker.lorem.paragraph()
+  let project = genData.newProject();
 
     it('TC_02.004.03 | Modify the description field for the pipeline', () => {
       
@@ -24,11 +26,11 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
                 .selectPipelineProject()
                 .clickOKButton()
       pipelinePage.typePipelineDescription(pipelineDescription)
-                  .clickOnSaveBtn()
-                  .clickConfigurePipelineMenuButton()
+                  .clickSaveButton()
+                  .clickConfigureLMenuOption()
                   .clearPipelineDescriptionField()
                   .typePipelineDescription(newPipelineDescription)
-                  .clickOnSaveBtn()
+                  .clickSaveButton()
       
       pipelinePage.getPipelineJobDescription()
                   .should('contain.text', newPipelineDescription)
@@ -42,9 +44,23 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
       pipelinePage
                 .typePipelineDescription(pipelineDescription)
                 .clickOnToggle()
-                .clickOnSaveBtn()
+                .clickSaveButton()
                 .getStatusDisabledText().should('exist')
                 .and('have.css', 'color', 'rgb(254, 130, 10)'); 
-  }) 
+    })
+    
+    it('TC_02.004.04 | Verify the choice of the pipeline script directly in Jenkins, using the editor', () => {
+      dashboardPage.clickCreateJobLink();
+      newJobPage.typeNewItemName(project.name)
+                .selectPipelineProject()
+                .clickOKButton();
+      pipelinePage.clickPipelineMenuOption()
+                  .clickPipelineScriptDropdownOption()
+                  .selectScriptedPipelineOption()
+                  .clickSaveButton()
+                  .clickConfigureMenuOption()
+                  .clickPipelineMenuOption();
 
+      pipelinePage.getPipelineScriptDropdownOption().should('be.selected').and('be.visible');  
+    });
 })

--- a/cypress/pageObjects/PipelinePage.js
+++ b/cypress/pageObjects/PipelinePage.js
@@ -3,15 +3,20 @@ import BasePage from "./basePage"
 
 class PipelinePage extends BasePage { 
 
-    getPipelineSaveBtn = () => cy.get('.jenkins-submit-button');
+    getSaveButton = () => cy.get('.jenkins-submit-button');
     getPipelineDescriptionField = () => cy.get('textarea[name="description"]')
-    getConfigurePipelineMenuButton = () => cy.get('a[href$="configure"]')
+    getConfigureMenuOption = () => cy.get('a[href$="configure"]')
     getPipelineJobDescription = () => cy.get('#description')
     getStatusDisabledText = () => cy.get('#enable-project').contains('currently disabled');
     getToggleSelector = () => cy.get('#enable-disable-project');
+    getPipelineScriptDropdownOption = () => cy.get('.jenkins-select__input.dropdownList').contains('Pipeline script');
+    getScriptedPipelineDropdownOption = () => cy.get('.samples > select').contains('Scripted Pipeline');
+    getScriptEditorDropdown = () => cy.get('.samples > select');
+    getScriptEditorInputField = () => cy.get('.ace_content');
+    getPipelineMenuOption = () => cy.get('button[data-section-id="pipeline"]');
 
-    clickOnSaveBtn() {
-        this.getPipelineSaveBtn().click()
+    clickSaveButton() {
+        this.getSaveButton().click()
         return this
     }
 
@@ -20,8 +25,8 @@ class PipelinePage extends BasePage {
         return this
     }
 
-    clickConfigurePipelineMenuButton() {
-        this.getConfigurePipelineMenuButton().click()
+    clickConfigureMenuOption() {
+        this.getConfigureMenuOption().click()
         return this
     }
 
@@ -34,6 +39,22 @@ class PipelinePage extends BasePage {
         this.getToggleSelector().uncheck({force:true});
         return this
     }
+ 
+    clickPipelineMenuOption() {
+        this.getPipelineMenuOption().click()
+        return this
+    }
+
+    clickPipelineScriptDropdownOption() {
+        this.getPipelineScriptDropdownOption().contains('Pipeline script').click({force: true})
+        return this
+    }
+
+    selectScriptedPipelineOption() {
+        this.getScriptEditorDropdown().select('Scripted Pipeline')
+        return this
+    }
+
 }
 
 export default PipelinePage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to `pipelinePipelineConfigurationPOM.cy.js`:
- Added the import statement for 'faker' library from `genData.js`;
- Added a variable `project` for `faker`  further usage (from /fixtures/genData);
2. Made changes to `PipelinePage.js`:
- Renamed the getters: `getPipelineSaveBtn` to `getSaveButton`, `getConfigurePipelineMenuButton` to `getConfigureMenuOption`;
- Renamed the methods: `clickOnSaveBtn()` to `clickSaveButton()`, `clickConfigurePipelineMenuButton()` to `clickConfigureMenuOption()`;
- Added getters:  `getPipelineScriptDropdownOption, getScriptedPipelineDropdownOption, getScriptEditorDropdown, getScriptEditorInputField, getPipelineMenuOption`;
- Added methods: `clickPipelineMenuOption(), clickPipelineScriptDropdownOption(), selectScriptedPipelineOption()`.

[Link to Github board card](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/638)
[Link to US](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/114)