### PR TITLE
TC_02.004.05 | Pipeline > Pipeline Configuration | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control

### DIFF
--- a/cypress/e2e/newItemCreateNewItemPOM.cy.js
+++ b/cypress/e2e/newItemCreateNewItemPOM.cy.js
@@ -6,6 +6,7 @@ import Header from "../pageObjects/Header";
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import FreestyleProjectPage from '../pageObjects/FreestyleProjectPage';
+import PipelinePage from '../pageObjects/PipelinePage';
 
 import allKeys from "../fixtures/newJobPageData.json";
 import {newItem} from "../fixtures/messages.json";
@@ -14,6 +15,7 @@ const header = new Header();
 const dashboardPage = new DashboardPage();
 const newJobPage = new NewJobPage();
 const freestyleProjectPage = new FreestyleProjectPage();
+const pipelinePage = new PipelinePage();
 
 const { projectName, projectNameInvalid, errorMessageColor } = allKeys;
 
@@ -169,7 +171,7 @@ describe("US_00.000 | New Item > Create New item", () => {
                   .clickOKButton();
 
         newJobPage.getUrlConfigurePageField().should('include', '/configure');
-        newJobPage.configurePagePipelineButton().should('be.visible');
+        pipelinePage.getPipelineMenuOption().should('be.visible');
     })
 
     it('TC_00.000.13 | Verify that after saving, new item is present on dashboard', () => {

--- a/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
+++ b/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
@@ -68,7 +68,7 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
       pipelinePage.getPipelineScriptDropdownOption().should('be.selected').and('be.visible');  
     });
 
-    it.only('TC_02.004.05 | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control', () => {
+    it('TC_02.004.05 | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control', () => {
 
       dashboardPage.clickCreateJobLink();
       newJobPage.typeNewItemName(project.name)
@@ -83,7 +83,7 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
                   .clickPipelineMenuOption();
     
       cy.log('Verifying that the "Pipeline script from SCM" is selected and the "Repository URL" is visible');           
-      pipelinePage.getPipelineScriptFromSCMDropdownOption()
+      pipelinePage.getDefinitionDropdown()
                   .find('option:selected')
                   .should('contain.text', 'Pipeline script from SCM')
                   .and('be.visible');

--- a/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
+++ b/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
@@ -68,7 +68,7 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
       pipelinePage.getPipelineScriptDropdownOption().should('be.selected').and('be.visible');  
     });
 
-    it('TC_02.004.05 | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control', () => {
+    it.only('TC_02.004.05 | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control', () => {
 
       dashboardPage.clickCreateJobLink();
       newJobPage.typeNewItemName(project.name)

--- a/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
+++ b/cypress/e2e/pipelinePipelineConfigurationPOM.cy.js
@@ -1,11 +1,14 @@
 /// <reference types="cypress"/>
 
 import { faker } from "@faker-js/faker";
-import genData from "../fixtures/genData";
+
 import DashboardPage from "../pageObjects/DashboardPage";
 import NewJobPage from "../pageObjects/NewJobPage";
 import PipelinePage from "../pageObjects/PipelinePage";
 import BasePage from "../pageObjects/basePage";
+
+import pipelinePageData from "../fixtures/pipelinePageData.json";
+import genData from "../fixtures/genData";
 
 const dashboardPage = new DashboardPage();
 const newJobPage = new NewJobPage();
@@ -50,6 +53,7 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
     })
     
     it('TC_02.004.04 | Verify the choice of the pipeline script directly in Jenkins, using the editor', () => {
+
       dashboardPage.clickCreateJobLink();
       newJobPage.typeNewItemName(project.name)
                 .selectPipelineProject()
@@ -62,5 +66,29 @@ describe('US_02.004 | Pipeline > Pipeline Configuration', () => {
                   .clickPipelineMenuOption();
 
       pipelinePage.getPipelineScriptDropdownOption().should('be.selected').and('be.visible');  
+    });
+
+    it('TC_02.004.05 | Verify the choice of linking the pipeline to a Jenkinsfile stored in source control', () => {
+
+      dashboardPage.clickCreateJobLink();
+      newJobPage.typeNewItemName(project.name)
+                .selectPipelineProject()
+                .clickOKButton();
+      pipelinePage.clickPipelineMenuOption()
+                  .selectPipelineScriptFromSCMDropdownOption()
+                  .selectGitOption()
+                  .typeRepositoryURL(pipelinePageData.repositoryURL);
+      pipelinePage.clickSaveButton()
+                  .clickConfigureMenuOption()
+                  .clickPipelineMenuOption();
+    
+      cy.log('Verifying that the "Pipeline script from SCM" is selected and the "Repository URL" is visible');           
+      pipelinePage.getPipelineScriptFromSCMDropdownOption()
+                  .find('option:selected')
+                  .should('contain.text', 'Pipeline script from SCM')
+                  .and('be.visible');
+      pipelinePage.getRepositoryURLInputField()
+                  .should('have.value', pipelinePageData.repositoryURL)
+                  .and('be.visible');
     });
 })

--- a/cypress/fixtures/pipelinePageData.json
+++ b/cypress/fixtures/pipelinePageData.json
@@ -1,0 +1,3 @@
+{
+    "repositoryURL": "https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall.git"
+}

--- a/cypress/pageObjects/NewJobPage.js
+++ b/cypress/pageObjects/NewJobPage.js
@@ -15,7 +15,6 @@ class NewJobPage extends BasePage{
     getAllItemsList = () => cy.get('#items li');
     getUrlConfigurePageField = () => cy.location('href');
     getBreadcrumbsListItem = () => cy.get("[aria-current='page']");
-    configurePagePipelineButton = () => cy.get('button[data-section-id="pipeline"]');
     getEmptyNameFieldReminder = () => cy.get('div[class$="validation-message"]');
   
 

--- a/cypress/pageObjects/PipelinePage.js
+++ b/cypress/pageObjects/PipelinePage.js
@@ -69,7 +69,7 @@ class PipelinePage extends BasePage {
     }
     
     typeRepositoryURL(url) {
-      this.getRepositoryURLInputField().type(url)
+      this.getRepositoryURLInputField().type(url, {force: true})
     }
 }
 

--- a/cypress/pageObjects/PipelinePage.js
+++ b/cypress/pageObjects/PipelinePage.js
@@ -14,9 +14,9 @@ class PipelinePage extends BasePage {
     getScriptEditorDropdown = () => cy.get('.samples > select');
     getScriptEditorInputField = () => cy.get('.ace_content');
     getPipelineMenuOption = () => cy.get('button[data-section-id="pipeline"]');
-    getPipelineScriptFromSCMDropdownOption = () => cy.get(':nth-child(9) > :nth-child(2) > .jenkins-select > .jenkins-select__input');
+    getDefinitionDropdown = () => cy.get(':nth-child(9) > :nth-child(2) > .jenkins-select > .jenkins-select__input');
     getSCMDropdown = () => cy.get(':nth-child(9) > .jenkins-select > .jenkins-select__input');
-    getRepositoryURLInputField =() => cy.get('input[name="_.url"]');
+    getRepositoryURLInputField =() => cy.get('input[name="_.url"]').first();
 
     clickSaveButton() {
         this.getSaveButton().click()
@@ -59,7 +59,7 @@ class PipelinePage extends BasePage {
     }
 
     selectPipelineScriptFromSCMDropdownOption() {
-        this.getPipelineScriptFromSCMDropdownOption().select('Pipeline script from SCM')
+        this.getDefinitionDropdown().select('Pipeline script from SCM')
         return this
     }
     
@@ -69,7 +69,7 @@ class PipelinePage extends BasePage {
     }
     
     typeRepositoryURL(url) {
-      this.getRepositoryURLInputField().type(url, {force: true})
+      this.getRepositoryURLInputField().first().type(url)
     }
 }
 

--- a/cypress/pageObjects/PipelinePage.js
+++ b/cypress/pageObjects/PipelinePage.js
@@ -14,6 +14,9 @@ class PipelinePage extends BasePage {
     getScriptEditorDropdown = () => cy.get('.samples > select');
     getScriptEditorInputField = () => cy.get('.ace_content');
     getPipelineMenuOption = () => cy.get('button[data-section-id="pipeline"]');
+    getPipelineScriptFromSCMDropdownOption = () => cy.get(':nth-child(9) > :nth-child(2) > .jenkins-select > .jenkins-select__input');
+    getSCMDropdown = () => cy.get(':nth-child(9) > .jenkins-select > .jenkins-select__input');
+    getRepositoryURLInputField =() => cy.get('input[name="_.url"]');
 
     clickSaveButton() {
         this.getSaveButton().click()
@@ -55,6 +58,19 @@ class PipelinePage extends BasePage {
         return this
     }
 
+    selectPipelineScriptFromSCMDropdownOption() {
+        this.getPipelineScriptFromSCMDropdownOption().select('Pipeline script from SCM')
+        return this
+    }
+    
+    selectGitOption() {
+        this.getSCMDropdown().select('Git')
+        return this
+    }
+    
+    typeRepositoryURL(url) {
+      this.getRepositoryURLInputField().type(url)
+    }
 }
 
 export default PipelinePage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to `pipelinePipelineConfigurationPOM.cy.js`:
- Added the import statement for `pipelinePageData` from "../fixtures/pipelinePageData.json";
2. Made changes to `PipelinePage.js`:
- Added getters:  `getDefinitionDropdown, getSCMDropdown, getRepositoryURLInputField`;
- Added methods: `selectPipelineScriptFromSCMDropdownOption(), selectGitOption(), typeRepositoryURL(url)`;
3. Added `pipelinePageData.json` file.
4. Deleted the unnecessary getter `configurePagePipelineButton` from `NewJobPage.js`, and replaced it with `getPipelineMenuOption` in the corresponding test of `newItemCreateNewItemPOM.cy.js` ;
5. Made changes to `newItemCreateNewItemPOM.cy.js`:
- Added the import statement for `PipelinePage`, and the `pipelinePage` variable.

[Link to Github board card](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/642)
[Link to US](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/114)