### PR TITLE
RF_01.006.09 | FreestyleProject > Move project | Move a project from a folder to the Dashboard page

### DIFF
--- a/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectDeleteProjectPOM.cy.js
@@ -65,7 +65,7 @@ describe('US_01.004 | FreestyleProject > Delete Project', () => {
         dashboardPage.getCancelButton().should("be.visible");
 
         dashboardPage.clickCancelButton()
-          .getProjectName()
+          .getItemName()
           .should("have.text", project.name)
           .and("be.visible");
     });

--- a/cypress/e2e/freestyleProjectMoveProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectMoveProjectPOM.cy.js
@@ -151,7 +151,8 @@ describe('US_01.006 | FreestyleProject > Move project', () => {
             .clickMoveButton()
             .clickDashboardBreadcrumbsLink();
 
-        dashboardPage.getJobTitleLink().contains(project.name).should('exist');
+        dashboardPage.getJobTitleLink().contains(project.name)
+            .should('have.text', project.name).and('be.visible');
     })
 
     it('TC_01.006.10 | Verify a project is moved to an existing folder from the Project page', () => {

--- a/cypress/e2e/freestyleProjectMoveProjectPOM.cy.js
+++ b/cypress/e2e/freestyleProjectMoveProjectPOM.cy.js
@@ -93,7 +93,7 @@ describe('US_01.006 | FreestyleProject > Move project', () => {
         header.clickJenkinsLogo();
 
         dashboardPage.openProjectPage(folder.name);
-        folderPage.getProjectName()
+        folderPage.getItemName()
             .contains(project.name)
             .should('be.visible');
     });
@@ -121,8 +121,38 @@ describe('US_01.006 | FreestyleProject > Move project', () => {
                             .clickJenkinsLogo();
         dashboardPage.openProjectPage(project.folderName);
         
-        folderPage.getProjectName().should('have.text',project.name);
+        folderPage.getItemName().should('have.text',project.name);
     });
+
+    it('TC_01.006.09 | Move a project from a folder to the Dashboard page', () => {
+
+        dashboardPage.clickNewItemMenuOption();
+        newJobPage.typeNewItemName(project.name)
+            .selectFreestyleProject()
+            .clickOKButton();
+        freestyleProjectPage.clickSaveButton()
+            .clickJenkinsLogo();
+        dashboardPage.clickNewItemMenuOption();
+        newJobPage.typeNewItemName(folder.name)
+            .selectFolder()
+            .clickOKButton();
+        freestyleProjectPage.clickSaveButton()
+            .clickDashboardBreadcrumbsLink();
+        dashboardPage.clickProjectChevronIcon(project.name)
+            .clickMoveTheProjectButton();   
+        freestyleProjectPage.selectNewProjectDestination(`Jenkins » ${folder.name}`)
+            .clickMoveButton()
+            .clickDashboardBreadcrumbsLink();
+
+        dashboardPage.clickJobName(folder.name);
+        folderPage.clickItemName(project.name);
+        freestyleProjectPage.clickMoveMenuOption()
+            .selectNewProjectDestination(`Jenkins`)
+            .clickMoveButton()
+            .clickDashboardBreadcrumbsLink();
+
+        dashboardPage.getJobTitleLink().contains(project.name).should('exist');
+    })
 
     it('TC_01.006.10 | Verify a project is moved to an existing folder from the Project page', () => {
 
@@ -152,6 +182,7 @@ describe('US_01.006 | FreestyleProject > Move project', () => {
     
         cy.log('Verifying that the project was moved to the folder');
         dashboardPage.openProjectPage(project.folderName);
-        folderPage.getProjectName().should('contain.text', project.name).and('be.visible');
+        folderPage.getItemName().should('contain.text', project.name).and('be.visible');
     });
+    
 });

--- a/cypress/e2e/newItemCreateFolderPOM.cy.js
+++ b/cypress/e2e/newItemCreateFolderPOM.cy.js
@@ -26,7 +26,7 @@ describe("US_00.004 | New item > Create Folder", () => {
         folderPage.getBreadcrumps()
             .should('contain.text', folder.name);
         folderPage.clickJenkinsLogo();
-        dashboardPage.getProjectName(folder.name)
+        dashboardPage.getItemName(folder.name)
             .should('be.visible');
     });
 });

--- a/cypress/e2e/newItemCreateFreestyleProjectPOM.cy.js
+++ b/cypress/e2e/newItemCreateFreestyleProjectPOM.cy.js
@@ -49,7 +49,7 @@ describe('US_00.001 | New item > Create Freestyle Project', function () {
         freestyleProjectPage.clickSaveButton();
         header.clickJenkinsLogo();
 
-        dashboardPage.getProjectName().should('contain', folderName);
+        dashboardPage.getItemName().should('contain', folderName);
 
     });
 

--- a/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
+++ b/cypress/e2e/newItemCreatePipelineProjectPOM.cy.js
@@ -79,7 +79,7 @@ describe("US_00.002 | New Item > Create Pipeline Project", () => {
     header.clickJenkinsLogo();
 
     dashboardPage
-      .getProjectName()
+      .getItemName()
       .should('be.visible')
       .and('contain.text', project.name);
     dashboardPage

--- a/cypress/e2e/organisationFolderConfigurationPOM.cy.js
+++ b/cypress/e2e/organisationFolderConfigurationPOM.cy.js
@@ -50,7 +50,7 @@ describe("US_06.001 | Organisation folder > Configuration", () => {
         cy.url().should("match", new RegExp(`${encodedOrgFolderName}\/?$`));
 
         header.clickJenkinsLogo();
-        dashboardPage.getProjectName().contains(displayName).should("be.visible");
+        dashboardPage.getItemName().contains(displayName).should("be.visible");
     });
 
 

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -9,7 +9,7 @@ class DashboardPage extends BasePage {
   getJobTable = () => cy.get("#projectstatus");
   getJobTitleLink = () => cy.get(".model-link.inside");
   getManageJenkins = () => cy.get('a[href="/manage"]');
-  getProjectName = () => cy.get('*.jenkins-table__link span');//please rename to getItemName, so it can be reused
+  getItemName = () => cy.get('*.jenkins-table__link span');
   getItemChevronIcon = (itemName) => cy.get(`span:contains('${itemName}') + .jenkins-menu-dropdown-chevron`);
   getJobTableDropdownChevron = () => cy.get('.jenkins-table__link > .jenkins-menu-dropdown-chevron');
   getJobTableDropdownItem = () => cy.get('.jenkins-dropdown__item ');
@@ -53,7 +53,7 @@ class DashboardPage extends BasePage {
   }
 
   openProjectPage (projectName) {
-    this.getProjectName().contains(projectName).click();
+    this.getItemName().contains(projectName).click();
   }
 
   getSessionCookie(cookieName) {
@@ -63,7 +63,7 @@ class DashboardPage extends BasePage {
   }
 
   openDropdownForItem (projectName) {
-    this.getProjectName().contains(projectName)
+    this.getItemName().contains(projectName)
       .trigger("mouseover").should("be.visible");
     this.getItemChevronIcon(projectName)
       .click({ force: true });

--- a/cypress/pageObjects/FolderPage.js
+++ b/cypress/pageObjects/FolderPage.js
@@ -11,7 +11,7 @@ class FolderPage extends BasePage {
 
     getNewNameField = () => cy.get('input[name="newName"]');
     getFolderUrl = () => cy.url({ decode: true });
-    getProjectName = () => cy.get('*.jenkins-table__link span');//probably rename to getFolderName or see BasePage
+    getItemName = () => cy.get('*.jenkins-table__link span');
     getCreateAJobLink = () => cy.get('a[href="newJob"]');
     getDescriptionField = () => cy.get('[name$="description"]');
     getFolderDescription = () => cy.get('#view-message');
@@ -45,6 +45,11 @@ class FolderPage extends BasePage {
         this.getDescriptionField().type(description, {delay: 0});
         return this;
     };
+
+    clickItemName (itemName) {
+        this.getItemName().contains(itemName).click();
+        return this;
+    }
 };
 
 export default FolderPage;


### PR DESCRIPTION
**Implemented Changes:**

To 'FolderPage.js':

- renamed locator getProjectName -> **getItemName**
- added method **clickItemName()**

To 'DashboardPage.js':

- renamed locator getProjectName -> **getItemName**

Converted **TC_01.006.09 to POM** format.

____

**Description:** Move the project from the folder back to the dashboard page.

**Preconditions:**
A user is registered and logged in to the system
User is on the "Dashboard Page"
The project has already been moved to the folder and is located in it

**Steps:**

1. Click on folder name on dashboard page
2. Click on project name you want move
3. Click Move button on Sidebar
4. Select Jenkins in "Where do you want to move the Project to?" field from dropdown
5. Click Move button
6. Click on Dashboard breadcrumbs link

**Expected results:** the moved project is on dashboard page

____
tests passed locally

![v87gwZLBRi](https://github.com/user-attachments/assets/c23972d7-4b8e-4be3-bb3b-fc90044cd277)

