### PR TITLE
TC_09.001_6 | Manage Jenkins > Search settings | Verify go to required page by click on required item on search suggestion dropdown.

### DIFF
--- a/cypress/e2e/manageJenkinsSearchSettingsPOM.cy.js
+++ b/cypress/e2e/manageJenkinsSearchSettingsPOM.cy.js
@@ -7,13 +7,15 @@ import ManageJenkinsPage from "../pageObjects/ManageJenkinsPage";
 
 import messages from "../fixtures/messages.json";
 import searchResultsData from "../fixtures/searchResultsData.json"
+import ConfigurePage from "../pageObjects/ConfigurePage";
 
 const dashboardPage = new DashboardPage();
 const manageJenkinsPage = new ManageJenkinsPage();
-
+const configurePage = new ConfigurePage();
 
 const randomSearchWord = faker.animal.type() + faker.finance.accountNumber(3)   
 const listOfPossibleSearchResults = ["System", "Tools", "Security", "Credentials", "Credential Providers"]
+
 
 describe('US_09.001 | Manage Jenkins > Search settings', () =>{
 
@@ -59,4 +61,26 @@ describe('US_09.001 | Manage Jenkins > Search settings', () =>{
             .should('have.css', 'opacity', '0')
             .and('have.value', '')
     });
-});
+    it('TC_09.001_6 | Verify go to required page by click on required item on search suggestion dropdown.', () => {
+        dashboardPage.clickManageJenkins();
+       
+        let menuItems = [];
+        manageJenkinsPage.getMenuItems()
+          .each(($el) => {
+                menuItems.push($el.text().trim());
+          })
+          .then(() => {
+            cy.wrap(menuItems)
+              .then((array) => {       
+                    array.forEach((dropDownItem) => {
+                        if (dropDownItem !== 'Reload Configuration from Disk') {
+                            manageJenkinsPage.typeSearchWord(dropDownItem)    
+                                             .clickSearchResult(dropDownItem);
+                            cy.contains(`${dropDownItem}`).should('exist');
+                            configurePage.clickBreadcrumbsManageJenkins(); 
+                        }                  
+                    });                
+              });       
+            });    
+           });                
+});   

--- a/cypress/pageObjects/ConfigurePage.js
+++ b/cypress/pageObjects/ConfigurePage.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+import ManageJenkinsPage from "../pageObjects/ManageJenkinsPage";
+
+class ConfigurePage {
+   
+    getBreadcrumbsManageJenkins = () => cy.get('[href="/manage/"]');
+
+    clickBreadcrumbsManageJenkins() {
+        this.getBreadcrumbsManageJenkins().click();
+        return new ManageJenkinsPage();
+    }
+};
+export default ConfigurePage;

--- a/cypress/pageObjects/ManageJenkinsPage.js
+++ b/cypress/pageObjects/ManageJenkinsPage.js
@@ -1,12 +1,14 @@
 /// <reference types="cypress" />
 import DashboardPage from "../pageObjects/DashboardPage";
+import ConfigurePage from "./ConfigurePage";
 
 class ManageJenkinsPage extends DashboardPage{
 
     getSettingsSearchField = () => cy.get('#settings-search-bar');
     getNoResultsErrorMessage = () => cy.get('.jenkins-search__results__no-results-label');
-    getSearchResultList = () => cy.get('.jenkins-search__results > *');
-    getXButtonSearchField =()=>cy.get('.jenkins-search__shortcut');
+    getSearchResultList = () => cy.get('.jenkins-search__results > *');    
+    getXButtonSearchField =()=>cy.get('.jenkins-search__shortcut');   
+    getMenuItems = () => cy.get('.jenkins-section__items dl dt'); 
 
     typeSearchWord(word) {
         this.getSettingsSearchField().type(word);
@@ -27,6 +29,11 @@ class ManageJenkinsPage extends DashboardPage{
         this.getXButtonSearchField().click({ force: true });
         return this; 
       }
+      
+    clickSearchResult(word) {
+        this.getSearchResultList().contains(`${word}`).click({force: true});
+        return new ConfigurePage();
+    }
 };
 
 export default ManageJenkinsPage;


### PR DESCRIPTION
[TC_09.001_6](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/651) 

**Implemented Changes:**

1. Made changes to manageJenkinsSearchSettingsPOM.cy.js:

- Added import ConfigurePage from "../pageObjects/ConfigurePage";
- Added const configurePage = new ConfigurePage();

2. Made changes to ManageJenkinsPage.js:

- Added getters: getMenuItems; 
- Added methods: clickSearchResult(word);

3. Added ConfigurePage.js file.