### PR TITLE
TC_16.002.07 | Dashboard > Create View | Verify the possibility to configure different column sets for different views

### DIFF
--- a/cypress/e2e/dashboardCreateViewPOM.cy.js
+++ b/cypress/e2e/dashboardCreateViewPOM.cy.js
@@ -19,6 +19,7 @@ describe("US_16.002 | Dashboard > Create View", () => {
   let project = genData.newProject();
   let folder = genData.newProject();
   let view = genData.newProject();
+  let newView = genData.newProject();
 
   beforeEach(() => {
     dashboardPage.clickNewItemMenuLink();
@@ -106,6 +107,44 @@ describe("US_16.002 | Dashboard > Create View", () => {
                .clickOKButton()
 
     dashboardPage.getItemName().should('have.text', project.name)         
+  });
+
+  it('TC_16.002.07 | Verify the possibility to configure different column sets for different views', () => {
+
+    cy.log('Creating the 1st View');
+    dashboardPage.clickAddViewLink();
+    myViewsPage.typeViewName(view.name)
+               .clickListViewRadio()
+               .clickCreateButton()
+               .selectJobCheckbox(project.name)
+               .selectJobCheckbox(folder.name)
+               .clickAddColumnButton()
+               .selectGitBranchesMenuItem()
+               .clickOKButton();
+
+    cy.log('Creating the 2nd View');
+    dashboardPage.clickAddViewLink();
+    myViewsPage.typeViewName(newView.name)
+               .clickListViewRadio()
+               .clickCreateButton()
+               .selectJobCheckbox(project.name)
+               .selectJobCheckbox(folder.name)
+               .clickDeleteWeatherColumnButton()
+               .clickAddColumnButton()
+               .selectProjectDescriptionMenuItem()
+               .clickOKButton();
+
+    cy.log('Verifying that the 1st View contains the "Weather" column, includes the "Git branches" column, but lacks the "Description" column');
+    dashboardPage.clickViewLink(view.name);
+    dashboardPage.getWeatherColumn().should('be.visible').and('contain.text', 'W');
+    dashboardPage.getGitBranchesColumn().should('be.visible').and('contain.text', 'Git Branches');
+    dashboardPage.getDescriptionColumn().should('not.exist');
+
+    cy.log('Verifying that the 2nd View does not contain the "Weather" column, includes the "Description" column, but lacks the "Git branches" column');
+    dashboardPage.clickViewLink(newView.name);
+    dashboardPage.getWeatherColumn().should('not.exist');
+    dashboardPage.getDescriptionColumn().should('be.visible').and('contain.text', 'Description');
+    dashboardPage.getGitBranchesColumn().should('not.exist');
   });
 
 });

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -33,6 +33,9 @@ class DashboardPage extends BasePage {
   getAllItemNamesFromNameColumn = () => cy.get('table#projectstatus tbody tr a span');
   getBuildNowDropdownMenuItem = () => cy.get('button.jenkins-dropdown__item').contains('Build Now');
   getNotificationBar = () => cy.get('#notification-bar');
+  getGitBranchesColumn = () => cy.contains('.sortheader', 'Git Branches');
+  getWeatherColumn = () => cy.get('a[href="#"]').contains('W');
+  getDescriptionColumn =() => cy.get('a[href="#"]').contains('Description');
 
 
   selectNewItemFromDashboardChevron() {
@@ -153,6 +156,11 @@ class DashboardPage extends BasePage {
 
   clickBuildNowDropdownMenuItem() {
     this.getBuildNowDropdownMenuItem().click();
+    return this;
+  }
+
+  clickViewLink(viewName) {
+    this.getViewTab(viewName).click()
     return this;
   }
 

--- a/cypress/pageObjects/MyViewsPage.js
+++ b/cypress/pageObjects/MyViewsPage.js
@@ -11,7 +11,13 @@ class MyViewsPage extends DashboardPage{
   getCurrentViewBreadcrumbsItem = () => cy.get(".jenkins-breadcrumbs__list-item").eq(3);
   getMyViewsBreadcrumbsItem = () => cy.get(".jenkins-breadcrumbs__list-item").contains("My Views");
   getMyViewsRadio = () => cy.get('label[for="hudson.model.MyView"]');
-  getCheckboxForJob = () => cy.get('.listview-jobs .jenkins-checkbox')
+  getCheckboxForJob = () => cy.get('.listview-jobs .jenkins-checkbox');
+  getListViewRadio = () => cy.get('label[for="hudson.model.ListView"]');
+  getAddColumnButton = () => cy.findByRole('button', { name: /Add column/ });
+  getGitBranchesMenuItem = () => cy.contains('button.jenkins-dropdown__item ', 'Git Branches');
+  getOKButton = () => cy.findByRole('button', { name: /OK/ });
+  getDeleteWeatherColumnButton = () => cy.get('div[descriptorid="hudson.views.WeatherColumn"] button[title="Delete"]');
+  getProjectDescriptionMenuItem = () => cy.contains('button.jenkins-dropdown__item ', 'Project description');
 
   clickAddNewViewLink() {
     this.getAddNewViewLink().click();
@@ -46,6 +52,37 @@ class MyViewsPage extends DashboardPage{
     this.getCheckboxForJob().contains(itemName).click()
     return this
   }
+
+  clickListViewRadio() {
+    this.getListViewRadio().click();
+    return this;
+  }
+
+  clickAddColumnButton() {
+    this.getAddColumnButton().click();
+    return this;
+  }
+
+  selectGitBranchesMenuItem() {
+    this.getGitBranchesMenuItem().contains('Git Branches').click();
+    return this;
+  }
+
+  clickOKButton() {
+    this.getOKButton().click()
+    return this
+  }
+
+  clickDeleteWeatherColumnButton() {
+    this.getDeleteWeatherColumnButton().click()
+    return this
+  }
+
+  selectProjectDescriptionMenuItem() {
+    this.getProjectDescriptionMenuItem().contains('Project description').click();
+    return this;
+  }
+
 }
 
 export default MyViewsPage;


### PR DESCRIPTION
Implemented Changes:

1. Made changes to `dashboardCreateViewPOM.cy.js`:
- Added the variable `newView` to generate another view name;
2. Made changes to `DashboardPage.js`:
- Added getters:  `getGitBranchesColumn, getWeatherColumn, getDescriptionColumn`;
- Added method: `clickViewLink(viewName)`;
3. Made changes to `MyViewsPage.js`:
- Added getters:  `getListViewRadio, getAddColumnButton, getGitBranchesMenuItem, getOKButton, getDeleteWeatherColumnButton, getProjectDescriptionMenuItem`;
- Added methods: `clickListViewRadio(), clickAddColumnButton(), selectGitBranchesMenuItem(), clickOKButton(), clickDeleteWeatherColumnButton(), selectProjectDescriptionMenuItem()`.

[Link to Github board card](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/666)
[Link to US](https://github.com/RedRoverSchool/JenkinsQA_JS_2024_fall/issues/332)