### PR TITLE
RF_13.001.01 | Create new User via Manage Jenkins left side menu

### DIFF
--- a/cypress/e2e/createNewUserPOM.cy.js
+++ b/cypress/e2e/createNewUserPOM.cy.js
@@ -21,7 +21,12 @@ describe('US_13.001 | Create new User', () => {
     manageJenkinsPage.clickUsersIcon();
     securityUsersPage.clickCreateUser();
 
-    // Use a single method to create a user
+    // Create a user
     addUserPage.createUser(userName, password, email);
+    
+    // User unique, password match, fullname
+    addUserPage.checkUserNameUnique();
+    addUserPage.checkPasswordMatch();
+    addUserPage.checkNullError();
   });
 });

--- a/cypress/e2e/createNewUserPOM.cy.js
+++ b/cypress/e2e/createNewUserPOM.cy.js
@@ -4,14 +4,18 @@ import DashboardPage from '../pageObjects/DashboardPage';
 import ManageJenkinsPage from '../pageObjects/ManageJenkinsPage';
 import SecurityUsersPage from '../pageObjects/SecurityUsersPage';
 import AddUserPage from '../pageObjects/AddUserPage';
+import LoginPage from "../pageObjects/LoginPage";
+import Header from "../pageObjects/Header";
 
 const dashboardPage = new DashboardPage();
 const manageJenkinsPage = new ManageJenkinsPage();
 const securityUsersPage = new SecurityUsersPage();
 const addUserPage = new AddUserPage();
+const loginPage = new LoginPage();
+const header = new Header();
 
 describe('US_13.001 | Create new User', () => {
-  let userName = 'userName';
+  let userName = 'Simon';
   const password = 'Password';
   const email = 'test@mail.com';
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -34,6 +38,28 @@ describe('US_13.001 | Create new User', () => {
 
     //Check user was created
     securityUsersPage.checkUserCreated(userName);
+
+    //Logout current user
+    dashboardPage.getLogOutButton().should('have.text', 'log out');
+    dashboardPage.clickLogOutButton();        
+
+    //Check correct page, sign in button exist
+    loginPage.getHeader().should('be.visible');
+    loginPage.getSignInButton().should('be.visible');
+
+    //Login with new username, password
+    loginPage.typeLogin(userName);
+    loginPage.typePassword(password);
+    loginPage.clickSignInButton();
+
+    //New user name is visible
+    dashboardPage.checkUserNameVisible(userName);
+
+
+
+
+
+
 
   });
 });

--- a/cypress/e2e/createNewUserPOM.cy.js
+++ b/cypress/e2e/createNewUserPOM.cy.js
@@ -23,43 +23,37 @@ describe('US_13.001 | Create new User', () => {
   userName = userName.toLowerCase();
 
   it('TC_13.001.01 | Create new User via Manage Jenkins left side menu', () => {
-    // Navigate through the application
+    
+    cy.log('Navigate through the application');
     dashboardPage.clickManageJenkins();
     manageJenkinsPage.clickUsersIcon();
     securityUsersPage.clickCreateUser();
 
-    // Create a user
+    cy.log('Creating user');
     addUserPage.createUser(userName, password, email);
-    
-    // User unique, password match, fullname
-    addUserPage.checkUserNameUnique();
-    addUserPage.checkPasswordMatch();
-    addUserPage.checkNullError();
+    addUserPage
+      .checkUserNameUniqueErrorMsg()
+      .checkPasswordMatchErrorMsg()
+      .checkNulErrorMsg();
 
-    //Check user was created
+    cy.log(`Verifying user "${userName}" was created successfully`);
     securityUsersPage.checkUserCreated(userName);
 
-    //Logout current user
+    cy.log('Log UI validation');
     dashboardPage.getLogOutButton().should('have.text', 'log out');
     dashboardPage.clickLogOutButton();        
 
-    //Check correct page, sign in button exist
+    cy.log('Verifying login page is displayed');
     loginPage.getHeader().should('be.visible');
     loginPage.getSignInButton().should('be.visible');
 
-    //Login with new username, password
-    loginPage.typeLogin(userName);
-    loginPage.typePassword(password);
-    loginPage.clickSignInButton();
+    cy.log(`Logging back in with username: ${userName}`);
+    loginPage
+      .typeLogin(userName)
+      .typePassword(password)
+      .clickSignInButton();
 
-    //New user name is visible
+    cy.log(`Checking that username "${userName}" is visible on the dashboard`);
     dashboardPage.checkUserNameVisible(userName);
-
-
-
-
-
-
-
   });
 });

--- a/cypress/e2e/createNewUserPOM.cy.js
+++ b/cypress/e2e/createNewUserPOM.cy.js
@@ -11,9 +11,12 @@ const securityUsersPage = new SecurityUsersPage();
 const addUserPage = new AddUserPage();
 
 describe('US_13.001 | Create new User', () => {
-  const userName = 'userName';
+  let userName = 'userName';
   const password = 'Password';
   const email = 'test@mail.com';
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  userName = userName.toLowerCase();
 
   it('TC_13.001.01 | Create new User via Manage Jenkins left side menu', () => {
     // Navigate through the application
@@ -28,5 +31,9 @@ describe('US_13.001 | Create new User', () => {
     addUserPage.checkUserNameUnique();
     addUserPage.checkPasswordMatch();
     addUserPage.checkNullError();
+
+    //Check user was created
+    securityUsersPage.checkUserCreated(userName);
+
   });
 });

--- a/cypress/e2e/oldTests/createNewUser.cy.js
+++ b/cypress/e2e/oldTests/createNewUser.cy.js
@@ -2,19 +2,29 @@
 
 describe('US_13.001 | Create new User', () => {
 
-  const userName = 'UserName';
+  const userName = 'userName';
   const password = 'Password';
-  const email = 'test@mail.com';
+  const email = 'user@email.com';
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   it('TC_13.001.01 | Create new User via Manage Jenkins left side menu', () => {
+
+    expect(email).to.match(emailRegex, 'The email is in a valid format');
+
     cy.get('a[href="/manage"]').click();
+    cy.url().should('include', '/manage');
     cy.get('a[href="securityRealm/"]').click();
+    cy.url().should('include', '/securityRealm');
     cy.get('a[href="addUser"]').click();
-    cy.get('#username').type(userName);
-    cy.get('input[name="password1"]').should('be.visible').type(password);
+    cy.url().should('include', '/addUser');
+    cy.get('#username').should('be.visible').and('be.enabled').type(userName);
+    cy.get('input[name="password1"]').should('be.visible').and('be.enabled').type(password);
     cy.get('input[name="password2"]').type(password);
     cy.get('input[name="email"]').type(email);
-    cy.get('.jenkins-button').eq("0").click({forse:true});
+    cy.get('[name="Submit"]').click({forse:true});
+
+    cy.contains('User name is already taken').should('not.exist');
+    cy.contains("Password didn't match").should('not.exist');
   })
 
 

--- a/cypress/e2e/oldTests/createNewUser.cy.js
+++ b/cypress/e2e/oldTests/createNewUser.cy.js
@@ -2,10 +2,13 @@
 
 describe('US_13.001 | Create new User', () => {
 
-  const userName = 'userName';
+  let userName = 'Simon';
   const password = 'Password';
   const email = 'user@email.com';
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  userName = userName.toLowerCase();
+
 
   it('TC_13.001.01 | Create new User via Manage Jenkins left side menu', () => {
 
@@ -22,7 +25,8 @@ describe('US_13.001 | Create new User', () => {
     cy.get('input[name="password2"]').type(password);
     cy.get('input[name="email"]').type(email);
     cy.get('[name="Submit"]').click({forse:true});
-
+    
+    cy.contains('a', userName).should('be.visible');  
     cy.contains('User name is already taken').should('not.exist');
     cy.contains("Password didn't match").should('not.exist');
     cy.contains('"null" is prohibited as a full name for security reasons').should('not.exist');

--- a/cypress/e2e/oldTests/createNewUser.cy.js
+++ b/cypress/e2e/oldTests/createNewUser.cy.js
@@ -26,10 +26,28 @@ describe('US_13.001 | Create new User', () => {
     cy.get('input[name="email"]').type(email);
     cy.get('[name="Submit"]').click({forse:true});
     
+    
     cy.contains('a', userName).should('be.visible');  
     cy.contains('User name is already taken').should('not.exist');
     cy.contains("Password didn't match").should('not.exist');
     cy.contains('"null" is prohibited as a full name for security reasons').should('not.exist');
+
+    //Logout from current session
+    cy.get('[href="/logout"]').should('be.visible');
+    cy.get('[href="/logout"] > .hidden-xs').click();
+
+    //Check correct page, sign in button exist
+    cy.get('.app-sign-in-register__content-inner').contains('Sign in to Jenkins').should('exist');
+    cy.url().should('eq', 'http://localhost:8080/login?from=%2F');
+
+    //Login with new username, password
+    cy.get('#j_username').type(userName);
+    cy.get('#j_password').type(password);
+    cy.get('button.jenkins-button--primary').click();
+    
+    //New user name is visible
+    cy.contains('a', userName).should('be.visible');  
+
   })
 
 

--- a/cypress/e2e/oldTests/createNewUser.cy.js
+++ b/cypress/e2e/oldTests/createNewUser.cy.js
@@ -24,7 +24,7 @@ describe('US_13.001 | Create new User', () => {
     cy.get('input[name="password1"]').should('be.visible').and('be.enabled').type(password);
     cy.get('input[name="password2"]').type(password);
     cy.get('input[name="email"]').type(email);
-    cy.get('[name="Submit"]').click({forse:true});
+    cy.findAllByRole ('button',{ name:/Create User/}).click();
     
     
     cy.contains('a', userName).should('be.visible');  
@@ -32,23 +32,20 @@ describe('US_13.001 | Create new User', () => {
     cy.contains("Password didn't match").should('not.exist');
     cy.contains('"null" is prohibited as a full name for security reasons').should('not.exist');
 
-    //Logout from current session
+    cy.log('Log UI validation');
     cy.get('[href="/logout"]').should('be.visible');
     cy.get('[href="/logout"] > .hidden-xs').click();
 
-    //Check correct page, sign in button exist
+    cy.log('Verifying login page is displayed');
     cy.get('.app-sign-in-register__content-inner').contains('Sign in to Jenkins').should('exist');
     cy.url().should('eq', 'http://localhost:8080/login?from=%2F');
 
-    //Login with new username, password
+    cy.log(`Logging back in with username: ${userName}`);
     cy.get('#j_username').type(userName);
     cy.get('#j_password').type(password);
     cy.get('button.jenkins-button--primary').click();
     
-    //New user name is visible
+    cy.log(`Checking that username "${userName}" is visible on the dashboard`);
     cy.contains('a', userName).should('be.visible');  
-
   })
-
-
 })

--- a/cypress/e2e/oldTests/createNewUser.cy.js
+++ b/cypress/e2e/oldTests/createNewUser.cy.js
@@ -25,6 +25,7 @@ describe('US_13.001 | Create new User', () => {
 
     cy.contains('User name is already taken').should('not.exist');
     cy.contains("Password didn't match").should('not.exist');
+    cy.contains('"null" is prohibited as a full name for security reasons').should('not.exist');
   })
 
 

--- a/cypress/pageObjects/AddUserPage.js
+++ b/cypress/pageObjects/AddUserPage.js
@@ -5,10 +5,10 @@ class AddUserPage {
   getPassword = () => cy.get('input[name="password1"]');
   getConfirmPassword = () => cy.get('input[name="password2"]');
   getEmail = () => cy.get('input[name="email"]');
-  getCreateUserBtn = () => cy.get('[name="Submit"]');
-  getUserNameUnique = () => cy.contains('User name is already taken');
-  getPasswordMatch = () => cy.contains("Password didn't match");
-  getNullError = () => cy.contains('"null" is prohibited as a full name for security reasons');
+  getCreateUserBtn = () => cy.findAllByRole ('button',{ name:/Create User/});
+  getUserNameUniqueErrorMsg = () => cy.contains('User name is already taken');
+  getPasswordMatchErrorMsg = () => cy.contains("Password didn't match");
+  getNulErrorMsg = () => cy.contains('"null" is prohibited as a full name for security reasons');
 
   typeUserName(userName) {
     this.getUserName().type(userName);
@@ -27,19 +27,22 @@ class AddUserPage {
   }
 
   clickCreateUserBtn() {
-    this.getCreateUserBtn().click({ force: true });
+    this.getCreateUserBtn().click();
   }
 
-  checkUserNameUnique() {
-    this.getUserNameUnique().should('not.exist');
+  checkUserNameUniqueErrorMsg() {
+    this.getUserNameUniqueErrorMsg().should('not.exist');
+    return this;
   }
 
-  checkPasswordMatch() {
-    this.getPasswordMatch().should('not.exist');
+  checkPasswordMatchErrorMsg() {
+    this.getPasswordMatchErrorMsg().should('not.exist');
+    return this;
   }
 
-  checkNullError() {
-    this.getNullError().should('not.exist');
+  checkNulErrorMsg() {
+    this.getNulErrorMsg().should('not.exist');
+    return this;
   }
 
   createUser(userName, password, email) {

--- a/cypress/pageObjects/AddUserPage.js
+++ b/cypress/pageObjects/AddUserPage.js
@@ -2,17 +2,20 @@
 
 class AddUserPage {
   getUserName = () => cy.get('#username');
-  getPassword = () => cy.get('.setting-main').eq(1);
-  getConfirmPassword = () => cy.get('.setting-main').eq(2);
-  getEmail = () => cy.get('.setting-main').eq(4);
-  getCreateUserBtn = () => cy.get('.jenkins-button').eq(0);
+  getPassword = () => cy.get('input[name="password1"]');
+  getConfirmPassword = () => cy.get('input[name="password2"]');
+  getEmail = () => cy.get('input[name="email"]');
+  getCreateUserBtn = () => cy.get('[name="Submit"]');
+  getUserNameUnique = () => cy.contains('User name is already taken');
+  getPasswordMatch = () => cy.contains("Password didn't match");
+  getNullError = () => cy.contains('"null" is prohibited as a full name for security reasons');
 
   typeUserName(userName) {
     this.getUserName().type(userName);
   }
 
   typePassword(password) {
-    this.getPassword().type(password);
+    this.getPassword().should('be.visible').and('be.enabled').type(password);
   }
 
   typeConfirmPassword(confirmPassword) {
@@ -25,6 +28,18 @@ class AddUserPage {
 
   clickCreateUserBtn() {
     this.getCreateUserBtn().click({ force: true });
+  }
+
+  checkUserNameUnique() {
+    this.getUserNameUnique().should('not.exist');
+  }
+
+  checkPasswordMatch() {
+    this.getPasswordMatch().should('not.exist');
+  }
+
+  checkNullError() {
+    this.getNullError().should('not.exist');
   }
 
   createUser(userName, password, email) {

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -158,6 +158,7 @@ class DashboardPage extends BasePage {
 
   checkUserNameVisible(userName) {
     this.getUserName(userName).should('be.visible');
+    return this;
   }
 
 };

--- a/cypress/pageObjects/DashboardPage.js
+++ b/cypress/pageObjects/DashboardPage.js
@@ -33,7 +33,7 @@ class DashboardPage extends BasePage {
   getAllItemNamesFromNameColumn = () => cy.get('table#projectstatus tbody tr a span');
   getBuildNowDropdownMenuItem = () => cy.get('button.jenkins-dropdown__item').contains('Build Now');
   getNotificationBar = () => cy.get('#notification-bar');
-
+  getUserName = (userName) => cy.contains('a', userName);
 
   selectNewItemFromDashboardChevron() {
     this.getJobTableDropdownItem().each(($els) => {
@@ -154,6 +154,10 @@ class DashboardPage extends BasePage {
   clickBuildNowDropdownMenuItem() {
     this.getBuildNowDropdownMenuItem().click();
     return this;
+  }
+
+  checkUserNameVisible(userName) {
+    this.getUserName(userName).should('be.visible');
   }
 
 };

--- a/cypress/pageObjects/LoginPage.js
+++ b/cypress/pageObjects/LoginPage.js
@@ -9,18 +9,22 @@ class LoginPage
       return cy.getCookies().then((cookies) => {
         return (cookies.find((cookie) => cookie.name.includes(cookieName))).value;
       });
+      return this
    }
    
    typeLogin(userName) {
       this.getLogin().type(userName)
+      return this
    }
 
    typePassword(password) {
       this.getPassword().type(password)
+      return this
    }
 
    clickSignInButton() {
       this.getSignInButton().click()
+      return this
    }
 
    verifyRedirectionToLoginPage() {

--- a/cypress/pageObjects/LoginPage.js
+++ b/cypress/pageObjects/LoginPage.js
@@ -1,13 +1,27 @@
 class LoginPage
 {
    getHeader = () => cy.get('h1').contains('Sign in to Jenkins');
-   getSignInButton = () => cy.get('button.jenkins-button--primary');   
+   getSignInButton = () => cy.get('button.jenkins-button--primary');
+   getLogin = () => cy.get('#j_username');
+   getPassword = () => cy.get('#j_password'); 
 
    getSessionCookie(cookieName) {
       return cy.getCookies().then((cookies) => {
         return (cookies.find((cookie) => cookie.name.includes(cookieName))).value;
       });
-   }   
+   }
+   
+   typeLogin(userName) {
+      this.getLogin().type(userName)
+   }
+
+   typePassword(password) {
+      this.getPassword().type(password)
+   }
+
+   clickSignInButton() {
+      this.getSignInButton().click()
+   }
 
    verifyRedirectionToLoginPage() {
       cy.url().should("include", "/login");

--- a/cypress/pageObjects/SecurityUsersPage.js
+++ b/cypress/pageObjects/SecurityUsersPage.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import AddUserPage from "../pageObjects/AddUserPage"
 
 class securityUsersPage {
   getCreateUser = () => cy.get('a[href="addUser"]');

--- a/cypress/pageObjects/SecurityUsersPage.js
+++ b/cypress/pageObjects/SecurityUsersPage.js
@@ -3,10 +3,14 @@ import AddUserPage from "../pageObjects/AddUserPage"
 
 class securityUsersPage {
   getCreateUser = () => cy.get('a[href="addUser"]');
-
+  getUserCreated = (userName) => cy.contains('a', userName);  
 
   clickCreateUser() {
     this.getCreateUser().click()
+  }
+
+  checkUserCreated(userName) {
+    this.getUserCreated(userName).should('be.visible')
   }
 
 };


### PR DESCRIPTION
This is Refactored TC_13.001.01

**Implemented Changes:**

Converted TC_13.001.01 to POM format.
Refactored RF_13.001.01: Added checks.

**Description:**
User can add new User via Manage Jenkins menu.

**Preconditions:**
User located on the Dashboard page.

**Steps:**
1. Click on Manage Jenkins link on the left side menu.
2. Go to Security section.
3. Click Users icon.
4. Click "Create User" button.
5. Enter uniq Username.
6. Enter valid Password.
7. Confirm password.
8. Enter valid E-mail address.
9. Click "Create User" button.
10. Logout from current user.
11. Login with new user.

**Expected results:**
New User created.
New user able to login